### PR TITLE
TIS2BG2 - Required changes to enable 64-bit unix operating systems

### DIFF
--- a/bgt/install/tis2bg2/.gitignore
+++ b/bgt/install/tis2bg2/.gitignore
@@ -1,0 +1,12 @@
+
+# CMake intermediate files
+cmake-build-*/
+
+# Test results
+tests/output/*
+
+# IDE
+.idea/
+
+# macOS files
+.DS_Store

--- a/bgt/install/tis2bg2/CMakeLists.txt
+++ b/bgt/install/tis2bg2/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.5)
+project(TIS2BG2)
+
+set(CMAKE_CXX_STANDARD 11)
+
+add_executable(tis2bg2
+    tis2bg2.cpp)
+
+set_target_properties(tis2bg2
+    PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin")

--- a/bgt/install/tis2bg2/build-osx-amd64.sh
+++ b/bgt/install/tis2bg2/build-osx-amd64.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+mkdir cmake-build-amd64-release
+cd cmake-build-amd64-release
+cmake .. -DCMAKE_CXX_FLAGS=-m64 -DCMAKE_C_FLAGS=-m64
+
+make
+
+cd ..
+mv ./bin/tis2bg2 ../osx/amd64/tis2bg2

--- a/bgt/install/tis2bg2/build-unix-amd64.sh
+++ b/bgt/install/tis2bg2/build-unix-amd64.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+mkdir cmake-build-amd64-release
+cd cmake-build-amd64-release
+cmake .. -DCMAKE_CXX_FLAGS=-m64 -DCMAKE_C_FLAGS=-m64
+
+make
+
+cd ..
+mv ./bin/tis2bg2 ../unix/amd64/tis2bg2

--- a/bgt/install/tis2bg2/build-win32-amd64.sh
+++ b/bgt/install/tis2bg2/build-win32-amd64.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+mkdir cmake-build-amd64-release
+cd cmake-build-amd64-release
+cmake .. -DCMAKE_CXX_FLAGS=-m64 -DCMAKE_C_FLAGS=-m64
+
+make
+
+cd ..
+mv ./bin/tis2bg2.exe ../win32/amd64/tis2bg2.exe


### PR DESCRIPTION
Changes:
- Updated c++ code to enable compilation on unix-based 64-bit systems
- Added subdirectory for tis2bg2 CMake project, created gitignore file
- Prepared scripts to compile and then move executables to the main directory

I recommend to not recompile tis2bg2 for Windows 64-bit system as it would require VC++ redistributable package installed on OS. I also suggest to merge tis2bg2 branch into master after this patch. I abandoned the rework of tis2bg2 source code, but I can continue if it is needed.
