### PR TITLE
Do not activate/deactivate Alora twice

### DIFF
--- a/bgt/base/baf/ar7230.baf
+++ b/bgt/base/baf/ar7230.baf
@@ -19,6 +19,7 @@ END
 IF
   TimeGT(19)
   Exists("Alora")
+  !IsActive("Alora")
   !InPartyAllowDead("Alora")
 THEN
   RESPONSE #100
@@ -29,6 +30,7 @@ END
 IF
   TimeLT(5)
   Exists("Alora")
+  !IsActive("Alora")
   !InPartyAllowDead("Alora")
 THEN
   RESPONSE #100
@@ -40,6 +42,7 @@ IF
   TimeGT(4)
   TimeLT(20)
   Exists("Alora")
+  IsActive("Alora")
   !InPartyAllowDead("Alora")
 THEN
   RESPONSE #100


### PR DESCRIPTION
AR7230 script can crash if Alora is destroyed by another script. Checking if Alora is already active/disactive prevents game to crash.