### PR TITLE
Polish Journal entries - more cleanup

### DIFF
--- a/bgt/language/polish/dialog.tra
+++ b/bgt/language/polish/dialog.tra
@@ -8,7 +8,7 @@
 @201817 = ~A co chcesz ¿ebym zrobi³?~
 @201818 = ~<CHARNAME>! Czy zwyciêstwo jest... twoje? Czy Sarevok... nie ¿yje?~
 @201819 = ~Tak, wype³ni³o siê przeznaczenie. Sarevok uleg³ memu ostrzu.~
-@201820 = ~I pomyœleæ, ¿e wychwalaliœmy go kilka godzin temu... ekhem~
+@201820 = ~I pomyœleæ, ¿e wychwalaliœmy go kilka godzin temu... ekhem...~
 @201821 = ~Mam nowy kontakt w Athkatli. Muszê zanieœæ ten dokument do niego, aby Rada Szeœciu mog³a go przeczytaæ i dowiedzieæ siê prawdy o sytuacji tutaj. Proponujê sekretne spotkanie z Rad¹. Mam nadziejê, ¿e zdo³am ich przekonaæ, i¿ to Sarevok by³ dla nich zagro¿eniem, a Wrota Baldura wcale nie chc¹ wojny.~
 @201822 = ~Mówiê ci o tym, gdy¿ takie wa¿ne zadanie mogê powierzyæ tylko tobie. Chcê byœ spotka³ siê z moim kontaktem i wrêczy³ mu ten list. Jeœli moi kurierzy nie mog¹ siê tam dostaæ z powodu bandytów, przynajmniej bêdê wiedzia³, ¿e zdo³asz ich pokonaæ i kontynuowaæ misjê w Athkatli.~
 @201823 = ~Athkatla? W Amn? To zabierze trochê czasu, by siê tam dostaæ. Czy jest jakiœ sposób, by przyspieszyæ moj¹ podró¿?~

--- a/bgt/language/polish/journal.tra
+++ b/bgt/language/polish/journal.tra
@@ -1,250 +1,250 @@
-@800000 = ~ZnajdŸ zagubion¹ ksi¹¿kê Phlydii.
+@800000 = ~ZnajdŸ zagubion¹ ksi¹¿kê Phlydii
 
 ~
-@800001 = ~ZnajdŸ zwój Identyfikacji Firebeada Elvenhaira.
+@800001 = ~ZnajdŸ zwój Identyfikacji Firebeada Elvenhaira
 
 ~
-@800002 = ~ZnajdŸ Antidotum dla Dreppina.
+@800002 = ~ZnajdŸ Antidotum dla Dreppina
 
 ~
-@800003 = ~Oczyœæ magazyn ze szczurów.
+@800003 = ~Oczyœæ magazyn ze szczurów
 
 ~
-@800004 = ~Przynieœ Hullowi jego miecz z baraków.
+@800004 = ~Przynieœ Hullowi jego miecz z baraków
 
 ~
-@800005 = ~Dostarcz ko³czan be³tów dla Fullera.
+@800005 = ~Dostarcz ko³czan be³tów dla Fullera
 
 ~
-@800006 = ~ZnajdŸ Pierœcieñ tañcz¹cego p³omienia Joii.
+@800006 = ~ZnajdŸ Pierœcieñ tañcz¹cego p³omienia Joii
 
 ~
-@800007 = ~ZnajdŸ 'Pas Przebiæ' dla Unshey.
+@800007 = ~ZnajdŸ 'Pas Przebiæ' dla Unshey
 
 ~
-@800008 = ~Paj¹ki, buty i wino.
+@800008 = ~Paj¹ki, buty i wino
 
 ~
-@800009 = ~Rodzina zombich.
+@800009 = ~Rodzina zombich
 
 ~
-@800010 = ~ZnajdŸ p³aszcz Gurke'a.
+@800010 = ~ZnajdŸ p³aszcz Gurke'a
 
 ~
-@800011 = ~Uczynek dla starego przyjaciela.
+@800011 = ~Uczynek dla starego przyjaciela
 
 ~
-@800012 = ~Buty Zhurlonga.
+@800012 = ~Buty Zhurlonga
 
 ~
-@800013 = ~Pó³-ogry siej¹ce panikê.
+@800013 = ~Pó³-ogry siej¹ce panikê
 
 ~
-@800014 = ~Ankhegowy los.
+@800014 = ~Ankhegowy los
 
 ~
-@800015 = ~Napaœæ barda lub napaœæ frajera.
+@800015 = ~Napaœæ barda lub napaœæ frajera
 
 ~
-@800016 = ~Zdob¹dŸ informacje o mê¿u Mirianne.
+@800016 = ~Zdob¹dŸ informacje o mê¿u Mirianne
 
 ~
-@800017 = ~Zdob¹dŸ miecz Perdue'a.
+@800017 = ~Zdob¹dŸ miecz Perdue'a
 
 ~
 @800018 = ~Syn Entara
 
 ~
-@800019 = ~W poszukiwaniu skalpów bandytów.
+@800019 = ~W poszukiwaniu skalpów bandytów
 
 ~
-@800020 = ~Kl¹twa kapitana Brage'a.
+@800020 = ~Kl¹twa kapitana Brage'a
 
 ~
-@800021 = ~Prism, z³odziej szmaragdów.
+@800021 = ~Prism, z³odziej szmaragdów
 
 ~
-@800022 = ~Uwolnij Dynaheir z twierdzy gnolli.
+@800022 = ~Uwolnij Dynaheir z twierdzy gnolli
 
 ~
-@800023 = ~Magowie.
+@800023 = ~Magowie
 
 ~
-@800024 = ~Zbadaj kopalnie Nashkel.
+@800024 = ~Zbadaj kopalnie Nashkel
 
 ~
-@800025 = ~ZnajdŸ Józefa w kopalni.
+@800025 = ~ZnajdŸ Józefa w kopalni
 
 ~
-@800026 = ~Zwróæ sztylet Kylee'go.
+@800026 = ~Sztylet Kylee
 
 ~
-@800027 = ~ZnajdŸ syna farmera Bruna, Natana.
+@800027 = ~ZnajdŸ syna farmera Bruna, Natana
 
 ~
-@800028 = ~Poskromienie ankhegów.
+@800028 = ~Poskromienie ankhegów
 
 ~
-@800029 = ~Kap³nka Umberlee.
+@800029 = ~Kap³nka Umberlee
 
 ~
-@800030 = ~Katastrofa ankhegów.
+@800030 = ~Katastrofa ankhegów
 
 ~
-@800031 = ~Polowanie na druidów.
+@800031 = ~Polowanie na druidów
 
 ~
-@800032 = ~ZnajdŸ Chelaka.
+@800032 = ~ZnajdŸ Chelaka
 
 ~
-@800033 = ~Porwanie Skie.
+@800033 = ~Porwanie Skie
 
 ~
-@800034 = ~Zbadaj siedzibê Siedmiu S³oñc.
+@800034 = ~Zbadaj siedzibê Siedmiu S³oñc
 
 ~
-@800035 = ~Zbadaj niewyjaœnione zaginiêcia mieszkañców.
+@800035 = ~Zbadaj niewyjaœnione zaginiêcia mieszkañców
 
 ~
-@800036 = ~Zbadaj siedzibê ¯elaznego Tronu.
+@800036 = ~Zbadaj siedzibê ¯elaznego Tronu
 
 ~
-@800037 = ~ZnajdŸ wolumin m¹droœci.
+@800037 = ~ZnajdŸ wolumin m¹droœci
 
 ~
-@800038 = ~Uratuj kotka Drienne.
+@800038 = ~Uratuj kotka Drienne
 
 ~
-@800039 = ~Ochroñ driadê z Chmurnych Szczytów.
+@800039 = ~Ochroñ driadê z Chmurnych Szczytów
 
 ~
-@800040 = ~Zaginiony piesek.
+@800040 = ~Zaginiony piesek
 
 ~
-@800041 = ~Dezerter z P³omiennej Piêœci.
+@800041 = ~Dezerter z P³omiennej Piêœci
 
 ~
-@800042 = ~Kradzie¿ p³aszcza Algernona.
+@800042 = ~Kradzie¿ p³aszcza Algernona
 
 ~
-@800043 = ~Sprawa bliŸniaczek.
+@800043 = ~Sprawa bliŸniaczek
 
 ~
-@800044 = ~Ekwipunek Baldurana.
+@800044 = ~Ekwipunek Baldurana
 
 ~
-@800045 = ~Historia Rzeki Jednoro¿ca.
+@800045 = ~Historia Rzeki Jednoro¿ca
 
 ~
-@800046 = ~Choroba Ghoraka.
+@800046 = ~Choroba Ghoraka
 
 ~
-@800047 = ~Dla piêkna.
+@800047 = ~Dla piêkna
 
 ~
-@800048 = ~Intryga z kotem.
+@800048 = ~Intryga z kotem
 
 ~
-@800049 = ~Kara za z³e uczynki.
+@800049 = ~Kara za z³e uczynki
 
 ~
-@800050 = ~Kl¹twa Yago.
+@800050 = ~Kl¹twa Yago
 
 ~
-@800051 = ~Zabij Sarevoka.
+@800051 = ~Zabij Sarevoka
 
 ~
-@800052 = ~Nowy ksi¹¿ê.
+@800052 = ~Nowy ksi¹¿ê
 
 ~
-@800053 = ~Zabójstwo Scara.
+@800053 = ~Zabójstwo Scara
 
 ~
-@800054 = ~Ponowna infiltracja ¯elaznego Tronu.
+@800054 = ~Ponowna infiltracja ¯elaznego Tronu
 
 ~
-@800055 = ~SprawdŸ lekarza ksiêcia Elthana, Rashada.
+@800055 = ~SprawdŸ lekarza ksiêcia Elthana, Rashada
 
 ~
-@800056 = ~Koniec.
+@800056 = ~Koniec
 
 ~
-@800057 = ~Zbadaj siedzibê P³omiennej Piêœci.
+@800057 = ~Zbadaj siedzibê P³omiennej Piêœci
 
 ~
-@800058 = ~Cena za moj¹ g³owê.
+@800058 = ~Cena za moj¹ g³owê
 
 ~
-@800059 = ~Nadchodz¹ca wojna.
+@800059 = ~Nadchodz¹ca wojna
 
 ~
-@800060 = ~ZnajdŸ odtrutkê.
+@800060 = ~ZnajdŸ odtrutkê
 
 ~
 @800061 = ~Shlimesh!
 
 ~
-@800062 = ~Uratuj syna Tremaina.
+@800062 = ~Uratuj syna Tremaina
 
 ~
-@800063 = ~Ucieczka Eurica.
+@800063 = ~Ucieczka Eurica
 
 ~
-@800064 = ~Krwawe uczynki.
+@800064 = ~Krwawe uczynki
 
 ~
-@800065 = ~Krwawe uczynki: Ordulinian.
+@800065 = ~Krwawe uczynki: Ordulinian
 
 ~
-@800066 = ~Krwawe uczynki: Nemphre.
+@800066 = ~Krwawe uczynki: Nemphre
 
 ~
-@800067 = ~Krwawe uczynki: Arkion.
+@800067 = ~Krwawe uczynki: Arkion
 
 ~
-@800068 = ~Z³odziejstwo dooko³a.
+@800068 = ~Z³odziejstwo dooko³a
 
 ~
-@800069 = ~Praca dla Alatosa.
+@800069 = ~Praca dla Alatosa
 
 ~
-@800070 = ~Zabij cz³owieka imieniem Cyrdemac.
+@800070 = ~Zabij cz³owieka imieniem Cyrdemac
 
 ~
-@800071 = ~Kradzie¿ teleskopu.
+@800071 = ~Kradzie¿ teleskopu
 
 ~
-@800072 = ~Dochodzenie w siedzibie Konsorcjum Kupieckiego.
+@800072 = ~Dochodzenie w siedzibie Konsorcjum Kupieckiego
 
 ~
-@800073 = ~Mi³oœæ i pierœcieñ anielskiej skóry.
+@800073 = ~Mi³oœæ i pierœcieñ anielskiej skóry
 
 ~
-@800074 = ~Rêkawice Noralee.
+@800074 = ~Rêkawice Noralee
 
 ~
-@800075 = ~Wtargniêcie syreny.
+@800075 = ~Wtargniêcie syreny
 
 ~
-@800076 = ~Samotny bazyliszek.
+@800076 = ~Samotny bazyliszek
 
 ~
-@800077 = ~ZnajdŸ kamieñ Sfin.
+@800077 = ~ZnajdŸ kamieñ Sfin
 
 ~
-@800078 = ~Mgliste odkrycia.
+@800078 = ~Mgliste odkrycia
 
 ~
-@800079 = ~Cenny skarb.
+@800079 = ~Cenny skarb
 
 ~
-@800080 = ~Œwiecide³ka.
+@800080 = ~Œwiecide³ka
 
 ~
-@800081 = ~Dzikie worgi.
+@800081 = ~Dzikie worgi
 
 ~
-@800082 = ~Deficyt ¿elaza.
+@800082 = ~Deficyt ¿elaza
 
 ~
 @800083 = ~NIEDWIED!
@@ -253,154 +253,154 @@
 @800084 = ~Bandyci!
 
 ~
-@800085 = ~Gadaj¹cy kurczak.
+@800085 = ~Gadaj¹cy kurczak
 
 ~
 @800086 = ~Zasadzka!
 
 ~
-@800087 = ~Ubiæ gibberlingi.
+@800087 = ~Ubiæ gibberlingi
 
 ~
-@800088 = ~Zatopienie kopalñ ¯elaznego Tronu.
+@800088 = ~Zatopienie kopalñ ¯elaznego Tronu
 
 ~
-@800089 = ~Ogrzy problem.
+@800089 = ~Ogrzy problem
 
 ~
-@800090 = ~Spetryfikowany wojownik.
+@800090 = ~Spetryfikowany wojownik
 
 ~
-@800091 = ~Zbadaj ruiny uczelni Ulcaster.
+@800091 = ~Zbadaj ruiny uczelni Ulcaster
 
 ~
-@800092 = ~Zombie.
+@800092 = ~Zombie
 
 ~
-@800093 = ~Zaginiony rycerz-duch.
+@800093 = ~Zaginiony rycerz-duch
 
 ~
 @800094 = ~Potwory atakuj¹ce z kopalni Nashkel?
 
 ~
-@800095 = ~Poszukiwane futra œnie¿nych wilków.
+@800095 = ~Poszukiwane futra œnie¿nych wilków
 
 ~
-@800096 = ~Archeologiczne wykopaliska.
+@800096 = ~Archeologiczne wykopaliska
 
 ~
-@800097 = ~St³umiæ archeologiczne wykopaliska.
+@800097 = ~St³umiæ archeologiczne wykopaliska
 
 ~
-@800098 = ~Zbadaæ ruiny mostu Firewine.
+@800098 = ~Zbadaæ ruiny mostu Firewine
 
 ~
-@800099 = ~Polowanie na wiwerny.
+@800099 = ~Polowanie na wiwerny
 
 ~
-@800100 = ~Okup za Skie.
+@800100 = ~Okup za Skie
 
 ~
-@800101 = ~Odzyskaæ sztylet Hurgana.
+@800101 = ~Odzyskaæ sztylet Hurgana
 
 ~
-@800102 = ~ZnajdŸ syna Therella'i, Daltona, w wie¿y Durlaga.
+@800102 = ~ZnajdŸ syna Therelli, Daltona, w wie¿y Durlaga
 
 ~
-@800103 = ~Zbadaj Wie¿ê Durlaga.
+@800103 = ~Zbadaj Wie¿ê Durlaga
 
 ~
-@800104 = ~Zbadaj Wie¿ê Durlaga: Zagadka - Sk¹pstwo.
+@800104 = ~Zbadaj Wie¿ê Durlaga: Zagadka - Sk¹pstwo
 
 ~
-@800105 = ~Zbadaj Wie¿ê Durlaga: Zagadka - Strach.
+@800105 = ~Zbadaj Wie¿ê Durlaga: Zagadka - Strach
 
 ~
-@800106 = ~Zbadaj Wie¿ê Durlaga: Zagadka - Mi³oœæ.
+@800106 = ~Zbadaj Wie¿ê Durlaga: Zagadka - Mi³oœæ
 
 ~
-@800107 = ~Zbadaj Wie¿ê Durlaga: Zagadki.
+@800107 = ~Zbadaj Wie¿ê Durlaga: Zagadki
 
 ~
-@800108 = ~Zbadaj Wie¿ê Durlaga: Zagadka - Duma.
+@800108 = ~Zbadaj Wie¿ê Durlaga: Zagadka - Duma
 
 ~
-@800109 = ~Mendas i ekspedycja Baldurana.
+@800109 = ~Mendas i ekspedycja Baldurana
 
 ~
-@800110 = ~Zdob¹dŸ mapy morskie.
+@800110 = ~Zdob¹dŸ mapy morskie
 
 ~
 @800111 = ~Rozbitkowie!
 
 ~
-@800112 = ~Pozbyæ siê "bestii" na wyspie.
+@800112 = ~Pozbyæ siê "bestii" na wyspie
 
 ~
-@800113 = ~Pogrom potwora.
+@800113 = ~Pogrom potwora
 
 ~
-@800114 = ~ZnajdŸ ksiêgê czarów Dradeela.
+@800114 = ~ZnajdŸ ksiêgê czarów Dradeela
 
 ~
-@800115 = ~ZnajdŸ brata Evalta.
+@800115 = ~ZnajdŸ brata Evalta
 
 ~
-@800116 = ~ZnajdŸ lalkê Farthing.
+@800116 = ~ZnajdŸ lalkê Farthing
 
 ~
-@800117 = ~Pomœcij ¿onê Lahla.
+@800117 = ~Pomœcij ¿onê Lahla
 
 ~
-@800118 = ~Uratuj dziecko Maralee.
+@800118 = ~Uratuj dziecko Maralee
 
 ~
-@800119 = ~Sprawunki dla Delainy.
+@800119 = ~Sprawunki dla Delainy
 
 ~
-@800120 = ~Odzyskaj symbol wioski, p³aszcz.
+@800120 = ~Odzyskaj symbol wioski, p³aszcz
 
 ~
-@800121 = ~ZnajdŸ kwiaty dla Delainy.
+@800121 = ~ZnajdŸ kwiaty dla Delainy
 
 ~
-@800122 = ~Zlecenia dla Durlyle'go.
+@800122 = ~Zlecenia dla Durlylego
 
 ~
-@800123 = ~ZnajdŸ kwiaty dla Durlyle'go.
+@800123 = ~ZnajdŸ kwiaty dla Durlylego
 
 ~
 @800124 = ~Dessthieftannien... cokolwiek...
 
 ~
-@800125 = ~Festiwal Nashkel.
+@800125 = ~Festiwal Nashkel
 
 ~
-@800126 = ~Nagrody i dary w Nashkel.
+@800126 = ~Nagrody i dary w Nashkel
 
 ~
-@800127 = ~Problem w Nashkel.
+@800127 = ~Problem w Nashkel
 
 ~
-@800128 = ~Niezwyk³oœci na zachód od Nashkel.
+@800128 = ~Niezwyk³oœci na zachód od Nashkel
 
 ~
 @800129 = ~Niepokój na po³udniu?
 
 ~
-@800130 = ~Wielka Komnata Cudów.
+@800130 = ~Wielka Komnata Cudów
 
 ~
 @800131 = ~Teleskop!
 
 ~
-@800132 = ~Ochrona Komnaty Cudów.
+@800132 = ~Ochrona Komnaty Cudów
 
 ~
-@800133 = ~Godziny otwarcia Komnaty Cudów.
+@800133 = ~Godziny otwarcia Komnaty Cudów
 
 ~
-@800134 = ~Mocna ochrona w Komnacie Cudów.
+@800134 = ~Mocna ochrona w Komnacie Cudów
 
 ~
 @800135 = ~Ochrona w Komnacie Cudów - prze³amana!
@@ -409,133 +409,133 @@
 @800136 = ~Sekretne katakumby Candlekeep!
 
 ~
-@800137 = ~Spotkania brata Aldetha.
+@800137 = ~Spotkania brata Aldetha
 
 ~
 @800138 = ~Jak bogaty jest Entar?
 
 ~
-@800139 = ~Przyczyna, by podejrzewaæ kupców we Wrotach Baldura.
+@800139 = ~Przyczyna, by podejrzewaæ kupców we Wrotach Baldura
 
 ~
-@800140 = ~Œcie¿ki z³a.
+@800140 = ~Œcie¿ki z³a
 
 ~
-@800141 = ~Koniec z harfiarzami.
+@800141 = ~Koniec z harfiarzami
 
 ~
 @800142 = ~Khalid i Jaheira s¹ harfiarzami!
 
 ~
-@800143 = ~Zaniepokojony farmer opowiada historiê.
+@800143 = ~Zaniepokojony farmer opowiada historiê
 
 ~
-@800144 = ~Niewinny farmer opowiada historiê.
+@800144 = ~Niewinny farmer opowiada historiê
 
 ~
-@800145 = ~Wyczekuj¹cy ojciec farmera jest nieszczêœliwy.
+@800145 = ~Wyczekuj¹cy ojciec farmera jest nieszczêœliwy
 
 ~
-@800146 = ~P³omienna Piêœæ œci¹gaj¹ca drowa.
+@800146 = ~P³omienna Piêœæ œci¹gaj¹ca drowa
 
 ~
-@800147 = ~Stary farmer lamentuj¹cy o kurczakach.
+@800147 = ~Stary farmer lamentuj¹cy o kurczakach
 
 ~
-@800148 = ~Podejrzewanie miejscowych.
+@800148 = ~Podejrzewanie miejscowych
 
 ~
-@800149 = ~¯eby podsumowaæ nasz¹ sytuacjê..
+@800149 = ~¯eby podsumowaæ nasz¹ sytuacjê...
 
 ~
 @800150 = ~Sobowtórniaki?
 
 ~
-@800151 = ~K³opotliwy problem k³opotliwego z³odzieja.
+@800151 = ~K³opotliwy problem k³opotliwego z³odzieja
 
 ~
-@800152 = ~Kolejna nudna opowieœæ barda.
+@800152 = ~Kolejna nudna opowieœæ barda
 
 ~
-@800153 = ~Spotkania z bardem.
+@800153 = ~Spotkania z bardem
 
 ~
-@800154 = ~S³awa dooko³a Wybrze¿a Mieczy.
+@800154 = ~S³awa dooko³a Wybrze¿a Mieczy
 
 ~
-@800155 = ~Wielki robal ko³o Beregostu.
+@800155 = ~Wielki robal ko³o Beregostu
 
 ~
-@800156 = ~Niepokoje wokó³ Beregostu.
+@800156 = ~Niepokoje wokó³ Beregostu
 
 ~
-@800157 = ~Rzeczy ojca.
+@800157 = ~Rzeczy ojca
 
 ~
-@800158 = ~Kobieta zamieniona w kamieñ.
+@800158 = ~Kobieta zamieniona w kamieñ
 
 ~
-@800159 = ~Druidzi Cienia.
+@800159 = ~Druidzi Cienia
 
 ~
-@800160 = ~Garrick, bard.
+@800160 = ~Garrick, bard
 
 ~
-@800161 = ~Muszê siê udaæ do Nashkel.
+@800161 = ~Muszê siê udaæ do Nashkel
 
 ~
 @800162 = ~Nastêpstwo?
 
 ~
-@800163 = ~Spokanie z Drizztem Do'Urdenem.
+@800163 = ~Spokanie z Drizztem Do'Urdenem
 
 ~
 @800164 = ~Zabójcy!
 
 ~
-@800165 = ~Wygl¹daj¹cy na starego mag œledzi mnie dooko³a.
+@800165 = ~Wygl¹daj¹cy na starego mag œledzi mnie dooko³a
 
 ~
-@800166 = ~ZnajdŸ Jaheirê i Khalida jeœli czujesz potrzebê.
+@800166 = ~ZnajdŸ Jaheirê i Khalida jeœli czujesz potrzebê
 
 ~
 @800167 = ~Stara dobra Imoen!
 
 ~
-@800168 = ~Litoœæ dla Marla.
+@800168 = ~Litoœæ dla Marla
 
 ~
-@800169 = ~Kolejny zabójca.
+@800169 = ~Kolejny zabójca
 
 ~
-@800170 = ~Targ na jarmarku w Nashkel.
+@800170 = ~Targ na jarmarku w Nashkel
 
 ~
 @800171 = ~Mnogoœæ zabójców!
 
 ~
-@800172 = ~B³¹d Oublek'a.
+@800172 = ~B³¹d Oubleka
 
 ~
-@800173 = ~B³¹d Oublek'a.
+@800173 = ~B³¹d Oubleka
 
 ~
 @800174 = ~Wiêcej zabójców?
 
 ~
-@800175 = ~Wieœæ od Volo.
+@800175 = ~Wieœæ od Volo
 
 ~
 @800176 = ~Volo da³ mi swój autograf!
 
 ~
-@800177 = ~Kap³anka zamieniona w kamieñ.
+@800177 = ~Kap³anka zamieniona w kamieñ
 
 ~
 @800178 = ~Dlaczego Shistal gra dziwnie?
 
 ~
-@800179 = ~Na ratunek Xanowi w Kopalni Nashkel.
+@800179 = ~Na ratunek Xanowi w Kopalni Nashkel
 
 ~
 @800180 = ~Rozdzia³ 2
@@ -559,455 +559,452 @@
 @800186 = ~Rozdzia³ 8
 
 ~
-@800187 = ~Spotkanie z Cadderly'm.
+@800187 = ~Spotkanie z Cadderlym
 
 ~
-@800188 = ~Przedmioty w starym pokoju Goriona.
+@800188 = ~Przedmioty w starym pokoju Goriona
 
 ~
-@800189 = ~Delthyr, Harfiarz.
+@800189 = ~Delthyr, Harfiarz
 
 ~
-@800190 = ~Opowieœæ Dradeela.
+@800190 = ~Opowieœæ Dradeela
 
 ~
-@800191 = ~Odnalezienie statku Baldurana.
+@800191 = ~Odnalezienie statku Baldurana
 
 ~
-@800192 = ~Zjawa w Wie¿y Durlaga.
+@800192 = ~Zjawa w Wie¿y Durlaga
 
 ~
-@800193 = ~Podejrzenia Pardy w Candlekeep.
+@800193 = ~Podejrzenia Pardy w Candlekeep
 
 ~
 @800194 = ~Sobowtórniaki nawiedzi³y Candlekeep!
 
 ~
-@800195 = ~Szalony Tiax.
+@800195 = ~Szalony Tiax
 
 ~
-@800196 = ~Malutki Quayle.
+@800196 = ~Malutki Quayle
 
 ~
-@800197 = ~Spotnkanie z bratem Aldetha.
+@800197 = ~Spotnkanie z bratem Aldetha
 
 ~
-@800198 = ~Lokatorzy Lasu Ostrych K³ów.
+@800198 = ~Lokatorzy Lasu Ostrych K³ów
 
 ~
-@800199 = ~Zasady Biblioteki Candlekeep.
+@800199 = ~Zasady Biblioteki Candlekeep
 
 ~
 @800200 = ~Poszukiwani za morderstwo!
 
 ~
-@800201 = ~Historia Marla.
+@800201 = ~Historia Marla
 
 ~
-@800202 = ~Nasz wyrok.
+@800202 = ~Nasz wyrok
 
 ~
-@800203 = ~Sanktuarium w Œwi¹tyni Umberlee.
+@800203 = ~Sanktuarium w Œwi¹tyni Umberlee
 
 ~
-@800204 = ~Szlachetny ³owca.
+@800204 = ~Szlachetny ³owca
 
 ~
-@800205 = ~Niepokój w Gildii Z³odziei.
+@800205 = ~Niepokój w Gildii Z³odziei
 
 ~
-@800206 = ~G³êbokie Piwnice.
+@800206 = ~G³êbokie Piwnice
 
 ~
-@800207 = ~Szko³a magii na wschód od Beregostu.
+@800207 = ~Szko³a magii na wschód od Beregostu
 
 ~
-@800208 = ~Zdob¹dŸ p³aszcz Shandalara.
+@800208 = ~Zdob¹dŸ p³aszcz Shandalara
 
 ~
 
 /////////////////////
 //New journal entries
 /////////////////////
-@310033 = ~Uczynek dla starego przyjaciela.
+@310033 = ~Uczynek dla starego przyjaciela
 
 Firebead Elvenhair da³ mi inn¹ ksi¹¿kê w zamian za "Historiê Monety Losu". Mówi, ¿e jest troszkê mroczniejsza od tej, któr¹ ja da³em mu. S¹dzi, ¿e powinna mi siê spodobaæ. Mam nadziejê, ¿e spotkam go ponownie. Zawsze by³ wspania³ym przyjacielem...~
-~Uczynek dla starego przyjaciela.
+~Uczynek dla starego przyjaciela
 
 Firebead Elvenhair da³ mi inn¹ ksi¹¿kê w zamian za "Historiê Monety Losu". Mówi, ¿e jest troszkê mroczniejsza od tej, któr¹ ja da³am mu. S¹dzi, ¿e powinna mi siê spodobaæ. Mam nadziejê, ¿e spotkam go ponownie. Zawsze by³ wspania³ym przyjacielem...~
-@310042 = ~Ankhegowa fortuna.
+@310042 = ~Ankhegowa fortuna
 
 Dziœ, Taerom "Grzmi¹cy M³ot" skoñczy³ pracê nad zbroj¹ p³ytow¹ z ankhega. To jest kawa³ dobrej roboty i nie mogê siê doczekaæ momentu za³o¿enia jej.~
-@310044 = ~Napaœæ barda lub napaœæ frajera.
+@310044 = ~Napaœæ barda lub napaœæ frajera
 
 Zostaliœmy wynajêci przez kobietê o imieniu Silke, która chce, ¿eby j¹ obroniæ przed opryszkami, wynajêtymi przez cz³owieka nazywaj¹cego siê Feldepost... Okaza³o siê, ¿e Silke jest z³¹ czarodziejk¹, która chcia³a zabiæ grupê pos³añców dla ich bogactw. Nie bêdzie wiêcej nikogo k³opotaæ.~
-@310045 = ~Napaœæ barda lub napaœæ frajera.
+@310045 = ~Napaœæ barda lub napaœæ frajera
 
 Pomogliœmy Silke pozbyæ siê grupy zbójów, którzy chcieli mnie oszukaæ i przekonaæ mnie, ¿e s¹ prostymi kupcami. Nie daliœmy siê z³apaæ na tê sztuczkê i pozbyliœmy siê ich szybko.~
-@311054 = ~W poszukiwaniu skalpów bandytów.
+@311054 = ~W poszukiwaniu skalpów bandytów
 
 Zrobiliœmy dobry interes sprzedaj¹c skalpy bandytów oficer Jessie Vai z P³omiennej Piêœci ale otrzyma³a powiadomienie z Wrót Baldura, od zwierzchników z poleceniem powrotu i zdania raportu o eliminacji problemów z bandytami. Czy mog³a zrobiæ biznes na garbowaniu lub wypychaniu zwierz¹t po tym wszystkim?~
-@310057 = ~Kl¹twa kapitana Brage'a.
+@310057 = ~Kl¹twa kapitana Brage'a
 
 Sprawa kapitana stra¿ny Nashkel by³a na pewno tragiczn¹ i zagmatwan¹ histori¹. Uporaliœmy siê z nim czy to z dobrym czy z³ym skutkiem.~
-@310806 = ~Prism, z³odziej szmaragdów.
+@310806 = ~Prism, z³odziej szmaragdów
 
 Opowieœæ Prisma by³a istotnie smutn¹ histori¹. Szkoda, ¿e nie mog³a mieæ lepszego zakoñczenie. Tak czy inaczej, op³aci³o nam siê to. W koñcu 150 sztuk z³ota za skradzione szmaragdy to nie jest ma³o.~
-@310070 = ~ZnajdŸ Józefa w kopalniach.
+@310070 = ~ZnajdŸ Józefa w kopalniach
 
 Znalaz³em w kopalni pierœcieñ Józefa, ale zatrzyma³em go, jako cenê za przys³ugê. Jego ¿ona nie by³a zadowolona, ale wszystko ma swoj¹ cenê.~
-~ZnajdŸ Józefa w kopalniach.
+~ZnajdŸ Józefa w kopalniach
 
 Znalaz³am w kopalni pierœcieñ Józefa, ale zatrzyma³am go, jako cenê za przys³ugê. Jego ¿ona nie by³a zadowolona, ale wszystko ma swoj¹ cenê.~
-@310071 = ~ZnajdŸ Józefa w kopalniach.
+@310071 = ~ZnajdŸ Józefa w kopalniach
 
 Znalaz³em w kopalni pierœcieñ Józefa i odda³em go jego ¿onie. By³a bardzo wdziêczna. Mogê mieæ tylko nadziejê, ¿e w samotnoœci znajdzie w nim wspomnienie o swoim mê¿u. Niech spoczywa w pokoju...~
-~ZnajdŸ Józefa w kopalniach.
+~ZnajdŸ Józefa w kopalniach
 
 Znalaz³am w kopalni pierœcieñ Józefa i odda³am go jego ¿onie. By³a bardzo wdziêczna. Mogê mieæ tylko nadziejê, ¿e w samotnoœci znajdzie w nim wspomnienie o swoim mê¿u. Niech spoczywa w pokoju...~
-@310078 = ~Zwróæ sztylet Kylee'go.
+@310078 = ~Sztylet Kylee
 
-Zwróci³em sztylet, który Dink da³ mi dla Kylee'go.~
-~Zwróæ sztylet Kylee'go.
-
-Zwróci³am sztylet, który Dink da³ mi dla Kylee'go.~
-@310086 = ~Poskromienie ankhegów.
+Kylee znów ma swój sztylet i wygl¹da na zdecydowanie mniej zdenerwowanego.~
+@310086 = ~Poskromienie ankhegów
 
 Gerde da³a mi 75 sztuk z³ota za moje zas³ugi w zmniejszeniu populacji ankhegów w tym regionie. Dobre pieni¹dze za ma³y wyczyn, naprawdê.~
-@311092 = ~Kap³nka Umberlee.
+@311092 = ~Kap³nka Umberlee
 
 M³oda kap³anka Umberlee nie ¿yje. Mam nadziejê, ¿e dostanê wkrótce nieco pomocy boskiej od Talosa... Œwie¿e rybki na ka¿dy obiad...~
-@310101 = ~Katastrofa ankhegów.
+@310101 = ~Katastrofa ankhegów
 
 Quinn by³ zadowolony odbieraj¹c sztylet Nestera. Mam nadziejê, ¿e bedzie mu dobrze s³u¿y³ w wspominaniu bohaterskich czynów Nestera. Niech spoczywa w pokoju.~
-@310103 = ~Polowanie na druidów.
+@310103 = ~Polowanie na druidów
 
 Stana³em po stronie druidów w sprawie ochrony natury Kniei Otulisko i zabi³em Aldetha Sashenstara. Podejrzewa³em go i jego bandê o polowanie na zmiennokszta³tnych druidów, i dobrze, ¿e druidzi maj¹ swoj¹ zemstê.~
-~Polowanie na druidów.
+~Polowanie na druidów
 
 Stanê³am po stronie druidów w sprawie ochrony natury Kniei Otulisko i zabi³am Aldetha Sashenstara. Podejrzewa³am go i jego bandê o polowanie na zmiennokszta³tnych druidów, i dobrze, ¿e druidzi maj¹ swoj¹ zemstê.~
-@310104 = ~Polowanie na druidów.
+@310104 = ~Polowanie na druidów
 
 Pomœci³em œmieræ Ebana, jednego z najbli¿szych przyjació³ Aldetha, pomagaj¹c mu w walce przeciw bandzie dzikusów. S¹ oni teraz wolni i mog¹ ³owiæ jak o to prosili. Aldeth wspomnia³ równie¿, ¿e powinienem odwiedziæ go w Lidze Kupieckiej, której budynek jest usytuowany w po³udniowo-zachodniej czêœæi Wrót Baldura jeœli tylko znajdê czas.~
-~Polowanie na druidów.
+~Polowanie na druidów
 
 Pomœci³am œmieræ Ebana, jednego z najbli¿szych przyjació³ Aldetha, pomagaj¹c mu w walce przeciw bandzie dzikusów. S¹ oni teraz wolni i mog¹ ³owiæ jak o to prosili. Aldeth wspomnia³ równie¿, ¿e powinnam odwiedziæ go w Lidze Kupieckiej, której budynek jest usytuowany w po³udniowo-zachodniej czêœæi Wrót Baldura jeœli tylko znajdê czas.~
-@310106 = ~ZnajdŸ Chelaka.
+@310106 = ~ZnajdŸ Chelaka
 
 Tiber by³ bardzo zgorznknia³y, gdy zwróci³em mu cia³o Chelaka. Biedny Chelak, samobójstwem by³a wyprawa do gniazda paj¹ków. Co do Tibera, nie mogê nic wiêcej jak wspó³czuæ mu.~
-~ZnajdŸ Chelaka.
+~ZnajdŸ Chelaka
 
 Tiber by³ bardzo zgorznknia³y, gdy zwróci³am mu cia³o Chelaka. Biedny Chelak, samobójstwem by³a wyprawa do gniazda paj¹ków. Co do Tibera, nie mogê nic wiêcej jak wspó³czuæ mu.~
-@310108 = ~Porwanie Skie.
+@310108 = ~Porwanie Skie
 
 Pomog³em Eldothowi uwolniæ Skie, ale zdawa³a mi siê byæ zbyt s³aba by towarzyszyæ mi w misji, dlatego pozwoli³em im odejœæ.~
-~Porwanie Skie.
+~Porwanie Skie
 
 Pomog³am Eldothowi uwolniæ Skie, ale zdawa³a mi siê byæ zbyt s³aba by towarzyszyæ mi w misji, dlatego pozwoli³am im odejœæ.~
-@310109 = ~Porwanie Skie.
+@310109 = ~Porwanie Skie
 
 Pomog³em Eldothowi uwolniæ Skie. By³a podniecona chêci¹ podró¿owania, ale nie jestem pewien czy da³aby radê znieœæ trudy wyprawy. Tak czy inaczej dam jej szansê i wypróbujê j¹.~
-~Porwanie Skie.
+~Porwanie Skie
 
 Pomog³am Eldothowi uwolniæ Skie. By³a podniecona chêci¹ podró¿owania, ale nie jestem pewna czy da³aby radê znieœæ trudy wyprawy. Tak czy inaczej dam jej szansê i wypróbujê j¹.~
-@310110 = ~Porwanie Skie.
+@310110 = ~Porwanie Skie
 
 Zabra³em Eldotha do pó³nocno-wschodniej czêœci Wrót Baldura gdzie mieœci siê siedziba, ale nie by³em pewien co do planu. Eldoth opuœci³ dru¿ynê, by samemu "uratowaæ" Skie.~
-~Porwanie Skie.
+~Porwanie Skie
 
-Zabra³am Eldotha do pó³nocno-wschodniej czêœci Wrót Baldura gdzie mieœci siê siedziba, ale nie by³am pewna co do planu. Eldoth opuœci³ dru¿ynê, by samemu 'uratowaæ' Skie.~
-@310111 = ~Porwanie Skie.
+Zabra³am Eldotha do pó³nocno-wschodniej czêœci Wrót Baldura gdzie mieœci siê siedziba, ale nie by³am pewna co do planu. Eldoth opuœci³ dru¿ynê, by samemu "uratowaæ" Skie.~
+@310111 = ~Porwanie Skie
 
-Wygl¹da na to, ¿e za d³ugo pomagaliœmy Eldothowi 'ratowaæ' Skie. Zwyczajnie nazwa³ nas g³upcami i odszed³ sobie. Jednak¿e, mam inne przeczucia kogo mo¿na nazwaæ g³upcem, lub samobójc¹.~
-@310115 = ~Zbadaj siedzibê Siedmiu S³oñc.
+Wygl¹da na to, ¿e za d³ugo pomagaliœmy Eldothowi "ratowaæ" Skie. Zwyczajnie nazwa³ nas g³upcami i odszed³ sobie. Jednak¿e, mam inne przeczucia kogo mo¿na nazwaæ g³upcem, lub samobójc¹.~
+@310115 = ~Zbadaj siedzibê Siedmiu S³oñc
 
 Oczyœciliœmy siedzibê Siedmiu S³oñc z sobowtórniaków i dostaliœmy ca³kiem niez³¹ nagrodê od Scara. Zdaje siê, ¿e chce od nas czegoœ jeszcze.~
-@310116 = ~Zbadaj siedzibê Siedmiu S³oñc.
+@310116 = ~Zbadaj siedzibê Siedmiu S³oñc
 
 Donios³em Scarowi, ¿e nie znalaz³em nic szczególnego w siedzibie Siedmiu S³oñc. Jednak¿e, Scar zdaje siê byæ bardziej zabsorbowany spraw¹ ¯elaznego Tronu.~
-~Zbadaj siedzibê Siedmiu S³oñc.
+~Zbadaj siedzibê Siedmiu S³oñc
 
 Donios³am Scarowi, ¿e nie znalaz³am nic szczególnego w siedzibie Siedmiu S³oñc. Jednak¿e, Scar zdaje siê byæ bardziej zabsorbowany spraw¹ ¯elaznego Tronu.~
-@310117 = ~Zbadaj siedzibê Siedmiu S³oñc.
+@310117 = ~Zbadaj siedzibê Siedmiu S³oñc
 
 Donios³em Scarowi, ¿e sobowtórniaki ogarnê³y siedzibê Siedmiu S³oñæ, ale nie chcê dalej tego badaæ. Jednak¿e, Scar zdaje siê byæ bardziej zabsorbowany spraw¹ ¯elaznego Tronu.~
-~Zbadaj siedzibê Siedmiu S³oñc.
+~Zbadaj siedzibê Siedmiu S³oñc
 
 Donios³am Scarowi, ¿e sobowtórniaki ogarnê³y siedzibê Siedmiu S³oñæ, ale nie chcê dalej tego badaæ. Jednak¿e, Scar zdaje siê byæ bardziej zabsorbowany spraw¹ ¯elaznego Tronu.~
-@310118 = ~Zbadaj siedzibê Siedmiu S³oñc.
+@310118 = ~Zbadaj siedzibê Siedmiu S³oñc
 
 Powiedzia³em Scarowi, ¿e sobowtórniaki s¹ dla nas zbyt przyt³aczaj¹cym problemem do rozwi¹zania. Zdaje siê, ¿e zrozumia³ nas i wyœle grupê P³omiennej Piêœci, by ta zajê³a siê t¹ spraw¹.~
-@310119 = ~Zbadaj siedzibê Siedmiu S³oñc.
+@310119 = ~Zbadaj siedzibê Siedmiu S³oñc
 
 Donios³em Scarowi, ¿e upora³em siê z sobowtórniakami, ale Jhasso zosta³ zabity. Scar nie zap³aci³ nam ale ma zamiar zatrudniæ nas ponownie.~
-~Zbadaj siedzibê Siedmiu S³oñc.
+~Zbadaj siedzibê Siedmiu S³oñc
 
 Donios³am Scarowi, ¿e upora³am siê z sobowtórniakami, ale Jhasso zosta³ zabity. Scar nie zap³aci³ nam ale ma zamiar zatrudniæ nas ponownie.~
-@310121 = ~Zbadaj niewyjaœnione zaginiêcia mieszkañców.
+@310121 = ~Zbadaj niewyjaœnione zaginiêcia mieszkañców
 
 Donios³em Scarowi, ¿e nie mog³em znaleŸæ ¿adnych wskazówek dotycz¹cych zaginiêæ mieszkañców. By³ raczej wœciek³y na nas i zagrozi³, ¿e zatrudni kogoœ innego. S¹dzê, ¿e musimy mu na to przystaæ.~
-~Zbadaj niewyjaœnione zaginiêcia mieszkañców.
+~Zbadaj niewyjaœnione zaginiêcia mieszkañców
 
 Donios³am Scarowi, ¿e nie mog³am znaleŸæ ¿adnych wskazówek dotycz¹cych zaginiêæ mieszkañców. By³ raczej wœciek³y na nas i zagrozi³, ¿e zatrudni kogoœ innego. S¹dzê, ¿e musimy mu na to przystaæ.~
-@310122 = ~Zbadaj niewyjaœnione zaginiêcia mieszkañców.
+@310122 = ~Zbadaj niewyjaœnione zaginiêcia mieszkañców
 
 Donios³em Scarowi, ¿e ogrzy mag sta³ za zaginiêciami. Niestety, pierœcieñ nale¿¹cy do rodziny Sashenstarów nie zosta³ znaleziony.~
-~Zbadaj niewyjaœnione zaginiêcia mieszkañców.
+~Zbadaj niewyjaœnione zaginiêcia mieszkañców
 
 Donios³am Scarowi, ¿e ogrzy mag sta³ za zaginiêciami. Niestety, pierœcieñ nale¿¹cy do rodziny Sashenstarów nie zosta³ znaleziony.~
-@310123 = ~Zbadaj niewyjaœnione zaginiêcia mieszkañców.
+@310123 = ~Zbadaj niewyjaœnione zaginiêcia mieszkañców
 
 Donios³em Scarowi, ¿e ogrzy mag sta³ za zaginiêciami i zwróci³em mu pierœcieñ nale¿¹cy do rodziny Sashenstarów.~
-~Zbadaj niewyjaœnione zaginiêcia mieszkañców.
+~Zbadaj niewyjaœnione zaginiêcia mieszkañców
 
 Donios³am Scarowi, ¿e ogrzy mag sta³ za zaginiêciami i zwróci³am mu pierœcieñ nale¿¹cy do rodziny Sashenstarów.~
-@310124 = ~Zbadaj niewyjaœnione zaginiêcia mieszkañców.
+@310124 = ~Zbadaj niewyjaœnione zaginiêcia mieszkañców
 
 Donios³em Scarowi, ¿e ogrzy mag sta³ za zaginiêciami i ¿e zabi³em potwora. Nie bêdzie wiêcej k³opota³ mieszkañców.~
-~Zbadaj niewyjaœnione zaginiêcia mieszkañców.
+~Zbadaj niewyjaœnione zaginiêcia mieszkañców
 
 Donios³am Scarowi, ¿e ogrzy mag sta³ za zaginiêciami i ¿e zabi³am potwora. Nie bêdzie wiêcej k³opota³ mieszkañców.~
-@310143 = ~ZnajdŸ wolumin m¹droœci.
+@310143 = ~ZnajdŸ wolumin m¹droœci
 
 Znalaz³em wolumin m¹droœci dla Fahringtona, ale pozwoli³ mi go zatrzymaæ. Ciekaw jestem jaki rodzaj "magicznej" esencji s³owa te zawieraj¹.~
-~ZnajdŸ wolumin m¹droœci.
+~ZnajdŸ wolumin m¹droœci
 
 Znalaz³am wolumin m¹droœci dla Fahringtona, ale pozwoli³ mi go zatrzymaæ. Ciekawa jestem jaki rodzaj "magicznej" esencji s³owa te zawieraj¹.~
-@310157 = ~Dezerter z P³omiennej Piêœci.
+@310157 = ~Dezerter z P³omiennej Piêœci
 
 Odda³em cia³o Samuela ¿o³nierzowi P³omiennej Piêœci, za co dosta³em 50 sztuk z³ota. Móg³ kupiæ mi chocia¿ miecz...~
-~Dezerter z P³omiennej Piêœci.
+~Dezerter z P³omiennej Piêœci
 
 Odda³am cia³o Samuela ¿o³nierzowi P³omiennej Piêœci, za co dosta³am 50 sztuk z³ota. Móg³ kupiæ mi chocia¿ miecz...~
-@310158 = ~Dezerter z P³omiennej Piêœci.
+@310158 = ~Dezerter z P³omiennej Piêœci
 
 Wychodzi na to, ¿e Lena przyczyni³a siê do tego, ¿e Samuel uciek³ z P³omiennej Piêœci. Niemniej jednak, mam nadziejê, ¿e Gellana mo¿e zrobiæ coœ ¿eby powróciæ tego biednego cz³owieka do zdrowia.~
-@310159 = ~Dezerter z P³omiennej Piêœci.
+@310159 = ~Dezerter z P³omiennej Piêœci
 
 Przynios³em Gellanie Samuela tak jak powiedzia³a Lena, ale by³o ju¿ za póŸno ¿eby mu pomóc. Co za strata ¿ycia...~
-~Dezerter z P³omiennej Piêœci.
+~Dezerter z P³omiennej Piêœci
 
 Przynios³am Gellanie Samuela tak jak powiedzia³a Lena, ale by³o ju¿ za póŸno ¿eby mu pomóc. Co za strata ¿ycia...~
-@310161 = ~Kradzie¿ p³aszcza Algernona.
+@310161 = ~Kradzie¿ p³aszcza Algernona
 
 Dostarczy³em p³aszcz Algernona dla Pheirkasa i zosta³em dostatecznie wynagrodzony...~
-~Kradzie¿ p³aszcza Algernona.
+~Kradzie¿ p³aszcza Algernona
 
 Dostarczy³am p³aszcz Algernona dla Pheirkasa i zosta³am dostatecznie wynagrodzona...~
-@310165 = ~Sprawa bliŸniaczek.
+@310165 = ~Sprawa bliŸniaczek
 
 Stan¹³em po dobrej stronie, po stronie druidki Voltine. Da³a mi ró¿d¿kê Polimorfii wzamian za pozbycie siê Gervisse'a.~
-~Sprawa bliŸniaczek.
+~Sprawa bliŸniaczek
 
 Stanê³am po dobrej stronie, po stronie druidki Voltine. Da³a mi ró¿d¿kê Polimorfii wzamian za pozbycie siê Gervisse'a.~
-@310166 = ~Sprawa bliŸniaczek.
+@310166 = ~Sprawa bliŸniaczek
 
 Doszliœmy do wniosku, ¿e to Voltine jest winna i pozbyliœmy siê jej dla Gervisse'a.~
-@310171 = ~Ekwipunek Baldurana.
+@310171 = ~Ekwipunek Baldurana
 
 Czarodziej Degrodel jest paskudny. Pomimo tego, ¿e zap³aci³ mi "królewsk¹" sumê, to jeszcze zes³a³ na mnie swoich stra¿ników. Prawdopodobnie powinienem zrobiæ co innego z tym he³mem...~
-~Ekwipunek Baldurana.
+~Ekwipunek Baldurana
 
 Czarodziej Degrodel jest paskudny. Pomimo tego, ¿e zap³aci³ mi "królewsk¹" sumê, to jeszcze zes³a³ na mnie swoich stra¿ników. Prawdopodobnie powininnam zrobiæ co innego z tym he³mem...~
-@310179 = ~Historia Rzeki Jednoro¿ca.
+@310179 = ~Historia Rzeki Jednoro¿ca
 
 Znalaz³em ksi¹¿kê Historii Rzeki Jednoro¿ca dla Rinnie.~
-~Historia Rzeki Jednoro¿ca.
+~Historia Rzeki Jednoro¿ca
 
 Znalaz³am ksi¹¿kê Historii Rzeki Jednoro¿ca dla Rinnie.~
-@310181 = ~Choroba Ghoraka.
+@310181 = ~Choroba Ghoraka
 
 Zwróci³em Agnasii czaszkê dawno zmar³ego kap³ana imieniem Kereph. Ghorak powinien byæ wyleczony z jego dolegliwoœci, wiêc powinienem mu z³o¿yæ przyjacielsk¹ wizytê w jego domu.~
-~Choroba Ghoraka.
+~Choroba Ghoraka
 
 Zwróci³am Agnasii czaszkê dawno zmar³ego kap³ana imieniem Kereph. Ghorak powinien byæ wyleczony z jego dolegliwoœci, wiêc powinnam mu z³o¿yæ przyjacielsk¹ wizytê w jego domu.~
-@310185 = ~Dla piêkna.
+@310185 = ~Dla piêkna
 
 Uwolni³em nimfê Abelê. Takie urodziwe stworzenie natury nie powinno ¿yæ w œwiecie paskudnych miast i og³upia³ych ludzi.~
-~Dla piêkna.
+~Dla piêkna
 
 Uwolni³am nimfê Abelê. Takie urodziwe stworzenie natury nie powinno ¿yæ w œwiecie paskudnych miast i og³upia³ych ludzi.~
-@311183 = ~Dla piêkna.
+@311183 = ~Dla piêkna
 
 W koñcu zdecydowa³em siê uwolniæ nimfê Abelê. Ragefast i Ramazith zdawali siê mieæ z³e intencje, wiêc zabi³em obu.~
-~Dla piêkna.
+~Dla piêkna
 
 W koñcu zdecydowa³am siê uwolniæ nimfê Abelê. Ragefast i Ramazith zdawali siê mieæ z³e intencje, wiêc zabi³am obu.~
-@310186 = ~Dla piêkna.
+@310186 = ~Dla piêkna
 
 Dostarczy³em nimfê Abelê do Ramazitha jak prosi³. To by³a bardzo powa¿na decyzja, ale nie jestem pewien czy mogê cokolwiek zmieniæ w tej kwestii.~
-~Dla piêkna.
+~Dla piêkna
 
 Dostarczy³am nimfê Abelê do Ramazitha jak prosi³. To by³a bardzo powa¿na decyzja, ale nie jestem pewna czy mogê cokolwiek zmieniæ w tej kwestii.~
-@311189 = ~Intryga z kotem.
+@311189 = ~Intryga z kotem
 
 Ju¿ po wszystkim. Zabi³em z³oœliwego kota. Przypuszczam, ¿e Bheren pomyœli dwa razy zanim spyta mnie o coœ, poniewa¿ zarz¹dam PRAWDZIWEJ zap³aty za czyn.~
-~Intryga z kotem.
+~Intryga z kotem
 
 Ju¿ po wszystkim. Zabi³am z³oœliwego kota. Przypuszczam, ¿e Bheren pomyœli dwa razy zanim spyta mnie o coœ, poniewa¿ zarz¹dam PRAWDZIWEJ zap³aty za czyn.~
-@310190 = ~Intryga z kotem.
+@310190 = ~Intryga z kotem
 
 Znalaz³em pierœcieñ Anielskiej Skóry dla Petrine. By³a bardzo wdziêczna.~
-~Intryga z kotem.
+~Intryga z kotem
 
 Znalaz³am pierœcieñ Anielskiej Skóry dla Petrine. By³a bardzo wdziêczna.~
-@310191 = ~Intryga z kotem.
+@310191 = ~Intryga z kotem
 
 Zabi³em kota... Ahh... biedna dziewczynka teraz p³acze... Co za strata...~
-~Intryga z kotem.
+~Intryga z kotem
 
 Zabi³am kota... Ahh... biedna dziewczynka teraz p³acze... Co za strata...~
-@310474 = ~Intryga z kotem.
+@310474 = ~Intryga z kotem
 
 I sta³o siê. Nieznoœny kot nie ¿yje, a Bheren obdarowa³ mnie magicznych p³aszczem. Hura!~
-@310199 = ~Kl¹twa Yago.
+@310199 = ~Kl¹twa Yago
 
 Zdobyliœmy ksiêgê kl¹tw Yago dla Brielbary. Dziêki niej bêdzie mog³a pomóc chorej córce. By³a wdziêczna.~
-@311199 = ~Kl¹twa Yago.
+@311199 = ~Kl¹twa Yago
 
 Nie mam zamiaru szukaæ tych starych, zakurzonych ksi¹¿ek... Dosyæ tego! Brielbara powinna sama zaopiekowaæ siê swoj¹ córk¹... Och... Jaka ona jest uparta... i martwa. Nie bêdê nigdy wiêcej za³atwiaæ takich spraw.~
-@310225 = ~ZnajdŸ odtrutkê.
+@310225 = ~ZnajdŸ odtrutkê
 
 Aczkolwiek przez szanta¿, Marek wyleczy³ mnie z trucizny. Otruli mnie poniewa¿ miesza³em siê w sprawy ¯elaznego Tronu. Teraz ju¿ bêdê uwa¿a³ co pijê.~
-~ZnajdŸ odtrutkê.
+~ZnajdŸ odtrutkê
 
 Aczkolwiek przez szanta¿, Marek wyleczy³ mnie z trucizny. Otruli mnie poniewa¿ miesza³am siê w sprawy ¯elaznego Tronu. Teraz ju¿ bêdê uwa¿aæ co pijê.~
-@310227 = ~Pijaczek.
+@310227 = ~Pijaczek
 
 Nigdy wiêcej gadania po piciu! Dosta³em moje 100 sztuk z³ota z powrotem plus 60 dodatkowo za pomoc w pozbyciu siê tych szlam. Jeœli 60 sztuk z³ota to wszystko co mia³, to s¹dzê, ¿e wytrzeŸwieje.~
-~Pijaczek.
+~Pijaczek
 
 Nigdy wiêcej gadania po piciu! Dosta³am moje 100 sztuk z³ota z powrotem plus 60 dodatkowo za pomoc w pozbyciu siê tych szlam. Jeœli 60 sztuk z³ota to wszystko co mia³, to s¹dzê, ¿e wytrzeŸwieje.~
-@310233 = ~Uratuj syna Tremaina.
+@310233 = ~Uratuj syna Tremaina
 
 Odzyska³em dziecko Tremaina. Wygl¹da na to, ¿e niegrzeczny ch³opiec wyszed³, by kraœæ w Œwi¹tyni Umberlee. Chyba nie bêdzie wiód³ lepszego ¿ycia ze swoim surowym ojcem. Varci by³ wdziêczny i da³ mi co nieco.~
-~Uratuj syna Tremaina.
+~Uratuj syna Tremaina
 
 Odzyska³am dziecko Tremaina. Wygl¹da na to, ¿e niegrzeczny ch³opiec wyszed³, by kraœæ w Œwi¹tyni Umberlee. Chyba nie bêdzie wiód³ lepszego ¿ycia ze swoim surowym ojcem. Varci by³ wdziêczny i da³ mi co nieco.~
-@310238 = ~Ucieczka Eurica.
+@310238 = ~Ucieczka Eurica
 
 Dosta³em ³adny amulet od Nadine, by oddaæ go jej synowi, Euricowi. Ufam jej s³owom, ¿e od teraz Euric bêdzie na siebie uwa¿a³.~
-~Ucieczka Eurica.
+~Ucieczka Eurica
 
 Dosta³am ³adny amulet od Nadine, by oddaæ go jej synowi, Euricowi. Ufam jej s³owom, ¿e od teraz Euric bêdzie na siebie uwa¿a³.~
-@311238 = ~Ucieczka Eurica.
+@311238 = ~Ucieczka Eurica
 
 Dostarczy³em szczêœliwy naszyjnik Euricowi. Nie by³ wdziêczny - ka¿dy dzieciak chce byæ wolny. Byæ mo¿e powinienem powiedzieæ Nadine, ¿e wszystko jest w porz¹dku z jej synem...~
-~Ucieczka Eurica.
+~Ucieczka Eurica
 
 Dostarczy³am szczêœliwy naszyjnik Euricowi. Nie by³ wdziêczny - ka¿dy dzieciak chce byæ wolny. Byæ mo¿e powinnam powiedzieæ Nadine, ¿e wszystko jest w porz¹dku z jej synem...~
-@310244 = ~Krwawe uczynki: Ordulinian.
+@310244 = ~Krwawe uczynki: Ordulinian
 
 Dostarczy³em Ordulinowi amulet z krwawnikiem Arkiona i onyksowy pierœcieñ Nemphre. Arkion i Nemphre nie bêd¹ wiêcej robiæ sobie k³opotów.~
-~Krwawe uczynki: Ordulinian.
+~Krwawe uczynki: Ordulinian
 
 Dostarczy³am Ordulinowi amulet z krwawnikiem Arkiona i onyksowy pierœcieñ Nemphre. Arkion i Nemphre nie bêd¹ wiêcej robiæ sobie k³opotów.~
-@310245 = ~Krwawe uczynki: Arkion.
+@310245 = ~Krwawe uczynki: Arkion
 
 Przynios³em Arkionowi cia³o z kana³ów. Nie mam pojêcia co on z nim zrobi, ani nie chcê wiedzieæ do kogo to cia³o nale¿a³o. Eh, ci nekromanci...~
-~Krwawe uczynki: Arkion.
+~Krwawe uczynki: Arkion
 
 Przynios³am Arkionowi cia³o z kana³ów. Nie mam pojêcia co on z nim zrobi, ani nie chcê wiedzieæ do kogo to cia³o nale¿a³o. Eh, ci nekromanci...~
-@310246 = ~Krwawe uczynki: Nemphre.
+@310246 = ~Krwawe uczynki: Nemphre
 
 Zdoby³em amulet z krwawnikiem Arkiona dla Nemphre. Odsunê³a mnie na bok jak pierwszego lepszego! Tak czy inaczej, nie chcê jej wchodziæ w drogê.~
-~Krwawe uczynki: Nemphre.
+~Krwawe uczynki: Nemphre
 
 Zdoby³am amulet z krwawnikiem Arkiona dla Nemphre. Odsunê³a mnie na bok jak pierwsz¹ lepsz¹! Tak czy inaczej, nie chcê jej wchodziæ w drogê.~
-@310265 = ~Zabij cz³owieka imieniem Cyrdemac.
+@310265 = ~Zabij cz³owieka imieniem Cyrdemac
 
 Zak³opotana kobieta imieniem Areana b³aga³a mnie bym zabi³ mê¿czyznê, który rozprzestrzenia³ k³amastwa o niej. Jego imiê to Cyrdemac i ostatnio przebywa w tawernie Elfia Pieœñ. Areanê mogê znaleŸæ w gospodzie Pod Trzema Bary³kami ko³o Pa³acu Ksi¹¿êcego.~
-~Zabij cz³owieka imieniem Cyrdemac.
+~Zabij cz³owieka imieniem Cyrdemac
 
 Zak³opotana kobieta imieniem Areana b³aga³a mnie bym zabi³a mê¿czyznê, który rozprzestrzenia³ k³amastwa o niej. Jego imiê to Cyrdemac i ostatnio przebywa w tawernie Elfia Pieœñ. Areanê mogê znaleŸæ w gospodzie Pod Trzema Bary³kami ko³o Pa³acu Ksi¹¿êcego.~
-@310267 = ~Zabij cz³owieka imieniem Cyrdemac.
+@310267 = ~Zabij cz³owieka imieniem Cyrdemac
 
 Odmówi³em pomocy oczernianej Areanie i nie zabi³em Cyrdemaca jak ona chcia³a. Coœ tu jest podejrzane i nie chcê staæ po którejkolwiek stronie.~
-~Zabij cz³owieka imieniem Cyrdemac.
+~Zabij cz³owieka imieniem Cyrdemac
 
 Odmówi³am pomocy oczernianej Areanie i nie zabi³am Cyrdemaca jak ona chcia³a. Coœ tu jest podejrzane i nie chcê staæ po którejkolwiek stronie.~
-@310268 = ~Zabij cz³owieka imieniem Cyrdemac.
+@310268 = ~Zabij cz³owieka imieniem Cyrdemac
 
 Usun¹³em Cyrdemaca i odebra³em nagrodê od Areany. Ufam, ¿e nie postawi ceny za moj¹ g³owê w zwi¹zku z moim czynem, chocia¿ jestem zainteresowany odgadniêciem jej ma³ego sekretu.~
-~Zabij cz³owieka imieniem Cyrdemac.
+~Zabij cz³owieka imieniem Cyrdemac
 
 Usunê³am Cyrdemaca i odebra³am nagrodê od Areany. Ufam, ¿e nie postawi ceny za moj¹ g³owê w zwi¹zku z moim czynem, chocia¿ jestem zainteresowana odgadniêciem jej ma³ego sekretu.~
-@310269 = ~Zabij cz³owieka imieniem Cyrdemac.
+@310269 = ~Zabij cz³owieka imieniem Cyrdemac
 
 Wiêc wydaje siê, ¿e zaj¹³em miejsce Cyrdemaca z korzyœci¹. Wszyscy bogaci teraz przychodz¹ do mnie, by utrzymaæ zabójstwa w sekrecie. Muszê wracaæ do Areany co dwa dni, by odbieraæ moje z³oto.~
-~Zabij cz³owieka imieniem Cyrdemac.
+~Zabij cz³owieka imieniem Cyrdemac
 
 Wiêc wydaje siê, ¿e zajê³am miejsce Cyrdemaca z korzyœci¹. Wszyscy bogaci teraz przychodz¹ do mnie, by utrzymaæ zabójstwa w sekrecie. Muszê wracaæ do Areany co dwa dni, by odbieraæ moje z³oto.~
-@310270 = ~Zabij cz³owieka imieniem Cyrdemac.
+@310270 = ~Zabij cz³owieka imieniem Cyrdemac
 
-Areana w koñcu sta³a siê trochê sprytniejsza i wynajê³a 'przyjaciela', który mia³by mnie zabiæ. Dobry pomys³.~
-@310266 = ~Zabij cz³owieka imieniem Cyrdemac.
+Areana w koñcu sta³a siê trochê sprytniejsza i wynajê³a "przyjaciela", który mia³by mnie zabiæ. Dobry pomys³.~
+@310266 = ~Zabij cz³owieka imieniem Cyrdemac
 
 Kiedy zafascynowa³em Cyrdemaca, powiedzia³ mi, ¿e szanta¿owa³ Areanê bo wiedzia³, ¿e ma ona kochanka w G³êbokich Piwnicach. Zasugerowa³ ¿ebym powiedzia³ jej, ¿e jest martwy i ¿ebym sam kontynuowa³ szanta¿owanie.~
-~Zabij cz³owieka imieniem Cyrdemac.
+~Zabij cz³owieka imieniem Cyrdemac
 
 Kiedy urzek³am Cyrdemaca, powiedzia³ mi, ¿e szanta¿owa³ Areanê bo wiedzia³, ¿e ma ona kochanka w G³êbokich Piwnicach. Zasugerowa³ ¿ebym powiedzia³a jej, ¿e jest martwy i ¿ebym sama kontynuowa³a szanta¿owanie.~
-@310272 = ~Kradzie¿ teleskopu.
+@310272 = ~Kradzie¿ teleskopu
 
 Brevlik by³ otumaniony rozg³osem o z³odzieju w Komnacie Cudów. Mogê powiedzieæ, ¿e obaj odnieœliœmy korzyœci, on teleskop, a ja nagrodê za przys³ugê.~
-~Kradzie¿ teleskopu.
+~Kradzie¿ teleskopu
 
 Brevlik by³ otumaniony rozg³osem o z³odzieju w Komnacie Cudów. Mogê powiedzieæ, ¿e zarówno on jak i ja odnieœliœmy korzyœci, on teleskop, a ja nagrodê za przys³ugê.~
-@310273 = ~Kradzie¿ teleskopu.
+@310273 = ~Kradzie¿ teleskopu
 
 Brevlik by³ trochê zdenerwowany, ¿e zabi³em kilku stra¿ników podczas mojej próby w Komnacie Cudów. Koniec sprawy, tak mówi.~
-~Kradzie¿ teleskopu.
+~Kradzie¿ teleskopu
 
 Brevlik by³ trochê zdenerwowany, ¿e zabi³am kilku stra¿ników podczas mojej próby w Komnacie Cudów. Koniec sprawy, tak mówi.~
-@310279 = ~Dochodzenie w siedzibie Konsorcjum Kupieckiego.
+@310279 = ~Dochodzenie w siedzibie Konsorcjum Kupieckiego
 
 Budynek zosta³ nawiedzony przez sobowtórniaki! Zrobi³em z nimi porz¹dek. Aldeth Sashenstar pochwali³ mnie za robotê i bêdzie szczêœliwy widz¹c mnie ponownie. Jeœli zajdzie potrzeba, mogê od niego uzyskaæ pomoc.~
-~Dochodzenie w siedzibie Konsorcjum Kupieckiego.
+~Dochodzenie w siedzibie Konsorcjum Kupieckiego
 
 Budynek zosta³ nawiedzony przez sobowtórniaki! Zrobi³am z nimi porz¹dek. Aldeth Sashenstar pochwali³ mnie za robotê i bêdzie szczêœliwy widz¹c mnie ponownie. Jeœli zajdzie potrzeba, mogê od niego uzyskaæ pomoc.~
-@311278 = ~Dochodzenie w siedzibie Konsorcjum Kupieckiego.
+@311278 = ~Dochodzenie w siedzibie Konsorcjum Kupieckiego
 
 Powiedzieliœmy Brandilarowi, ¿e wyeliminowaliœmy wszystkie sobowtórniki napotkane przy przeszukiwaniu budynku Konsorcjum Kupieckiego. Zasugerowa³ nam ¿ebyœmy siê zg³osili do Aldetha po nagrodê.~
-@310281 = ~Mi³oœæ i pierœcieñ anielskiej skóry.
+@310281 = ~Mi³oœæ i pierœcieñ anielskiej skóry
 
 Znalaz³em pierœcieñ anielskiej skóry i da³em go Fergusowi. Doceni³ mój gest i dosta³em pochwa³ê od Scara, drugiego w hierarchii P³omiennej Piêœci.~
-~Mi³oœæ i pierœcieñ anielskiej skóry.
+~Mi³oœæ i pierœcieñ anielskiej skóry
 
 Znalaz³am pierœcieñ anielskiej skóry i da³am go Fergusowi. Doceni³ mój gest i dosta³am pochwa³ê od Scara, drugiego w hierarchii P³omiennej Piêœci.~
-@310287 = ~Rêkawice Noralee.
+@310287 = ~Rêkawice Noralee
 
 Znalaz³em parê rêkawic dla Noralee. Znalezienie ich zajê³o mi trochê czasu. Jednak¿e, dosta³em nagrodê za wykonan¹ pracê.~
-~Rêkawice Noralee.
+~Rêkawice Noralee
 
 Znalaz³am parê rêkawic dla Noralee. Znalezienie ich zajê³o mi trochê czasu. Jednak¿e, dosta³am nagrodê za wykonan¹ pracê.~
-@310289 = ~Wtargniêcie syreny.
+@310289 = ~Wtargniêcie syreny
 
 Wyczyœci³em teren po³owów z problematycznych sirin dla Cordyra. To by³o trudne zadanie ale przynajmniej Cordyr mo¿e wróciæ do swojego normalnego ¿ycia.~
-~Wtargniêcie syreny.
+~Wtargniêcie syreny
 
 Wyczyœci³am teren po³owów z problematycznych sirin dla Cordyra. To by³o trudne zadanie ale przynajmniej Cordyr mo¿e wróciæ do swojego normalnego ¿ycia.~
-@310291 = ~Samotny bazyliszek.
+@310291 = ~Samotny bazyliszek
 
 Nadarin by³ bardzo wdziêczny... i bogaty równie¿! Zostaliœmy nagrodzeni ca³kiem przyzwoicie za pozbycie siê bazyliszka.~
-@310293 = ~ZnajdŸ kamieñ Sfin.
+@310293 = ~ZnajdŸ kamieñ Sfin
 
 G'Axir doceni³ moje zaanga¿owanie w poszukiwanie sfinu, ale jego ciemne wizje wobec mojej osoby wydaj¹ siê ca³kiem straszne. Widocznie, pod Wrotami Baldura mog¹ le¿eæ pradawne podziemia, gdzie muszê iœæ przez ciemnoœæ, by znaleŸæ œwiat³o. Brzmi jak fragment fantazyjnej ksi¹¿ki!~
-@310294 = ~Mgliste odkrycia.
+@310294 = ~Mgliste odkrycia
 
 Spotka³em Shaellê, jedn¹ z najbardziej d³ubi¹cych umys³ kap³anek jak¹ kiedykolwiek mia³em okazjê spotkaæ. Deklaruje czczenie Leiry, Pani Mgie³, która najwidoczniej nie istnieje. Jakoœ mam uczucie ¿eby móc z ni¹ rozmawiaæ muszê mówiæ przeciwnie to co myœlê.~
-~Mgliste odkrycia.
+~Mgliste odkrycia
 
 Spotka³am Shaellê, jedn¹ z najbardziej d³ubi¹cych umys³ kap³anek jak¹ kiedykolwiek mia³am okazjê spotkaæ. Deklaruje czczenie Leiry, Pani Mgie³, która najwidoczniej nie istnieje. Jakoœ mam uczucie ¿eby móc z ni¹ rozmawiaæ muszê mówiæ przeciwnie to co myœlê.~
-@310296 = ~Mgliste odkrycia.
+@310296 = ~Mgliste odkrycia
 
 B³ogos³awiony niewiedz¹ przez dotyk Wielkiej Ksiêgi Niewiedzy, która nie istnieje ale tak¿e k³amie, odkry³em na nowo fa³szywe oblicze Elnaedry, ignorantki Shaelli, kap³anki Leiry. Dlaczego to musi siê rymowaæ?!~
-~Mgliste odkrycia.
+~Mgliste odkrycia
 
 B³ogos³awiona niewiedz¹ przez dotyk Wielkiej Ksiêgi Niewiedzy, która nie istnieje ale tak¿e k³amie, odkry³am na nowo fa³szywe oblicze Elnaedry, ignorantki Shaelli, kap³anki Leiry. Dlaczego to musi siê rymowaæ?!~
-@310298 = ~Cenny skarb.
+@310298 = ~Cenny skarb
 
 ZnaleŸliœmy piracki skarb, którego poszukiwa³a Safana, ale poza jej pomoc¹ w zadaniu, nie odczuwam potrzeby posiadania tej specjalistki w mojej dru¿ynie.~
-@310299 = ~Cenny skarb.
+@310299 = ~Cenny skarb
 
 ZnaleŸliœmy piracki skarb, którego poszukiwa³a Safana i pozwoliliœmy jej do³¹czyæ do kompanii. S¹dzê, ¿e powinna siê przydaæ.~
 @310390 = ~NIEDWIED!
@@ -1016,130 +1013,130 @@ Jared powinien móc podró¿owaæ bezpieczniej po tym jak pozby³em siê problematyczn
 ~NIEDWIED!
 
 Jared powinien móc podró¿owaæ bezpieczniej po tym jak pozby³am siê problematycznego niedŸwiedzia. To nie by³ zwyk³y niedŸwiedŸ.~
-@310805 = ~Gadaj¹cy kurczak.
+@310805 = ~Gadaj¹cy kurczak
 
 Zabra³em kurczaka Melicampa do Thalantyra w Wysokim ¯ywop³ocie. Nie chia³bym widzieæ jak¹ karê poniesie, nie dlatego, ¿e mam coœ do niego, tylko raczej obraŸliwe zachowanie Thalantyra nie zostawia mi wyboru.~
-~Gadaj¹cy kurczak.
+~Gadaj¹cy kurczak
 
 Zabra³am kurczaka Melicampa do Thalantyra w Wysokim ¯ywop³ocie. Nie chia³abym widzieæ jak¹ karê poniesie, nie dlatego, ¿e mam coœ do niego, tylko raczej obraŸliwe zachowanie Thalantyra nie zostawia mi wyboru.~
-@310553 = ~Zombie.
+@310553 = ~Zombie
 
 Zabi³em dwudziestu zombich panosz¹cych siê wokó³ farmy Wenrica. Nie wiem sk¹d przyby³y, ale nie bêd¹ go wiêcej k³opotaæ.~
-~Zombie.
+~Zombie
 
 Zabi³am dwudziestu zombich panosz¹cych siê wokó³ farmy Wenrica. Nie wiem sk¹d przyby³y, ale nie bêd¹ go wiêcej k³opotaæ.~
-@310558 = ~Zaginiony rycerz-duch.
+@310558 = ~Zaginiony rycerz-duch
 
 Zwróci³em staro¿ytn¹ zbrojê nieumar³ego rycerza jego przyjacio³om. Wspomnieli, ¿e by³ on zdrajc¹ i z racji, ¿e znowu s¹ razem zyskali wolnoœæ. Spoczywaj¹ w pokoju?~
-~Zaginiony rycerz-duch.
+~Zaginiony rycerz-duch
 
 Zwróci³am staro¿ytn¹ zbrojê nieumar³ego rycerza jego przyjacio³om. Wspomnieli, ¿e by³ on zdrajc¹ i z racji, ¿e znowu s¹ razem zyskali wolnoœæ. Spoczywaj¹ w pokoju?~
-@310575 = ~Archeologiczne wykopaliska.
+@310575 = ~Archeologiczne wykopaliska
 
 Spotka³em inspiruj¹cego kopacza imieniem Charleston Nib na zachód od Nashkel. On i jego ekipa odkryli podziemn¹ osadê prymitywnych staro¿ytnch ludzi i s¹ bliscy wejœcia do jednej z wewnêtrznych komnat. Jednak¿e, byli na ³asce bandytów, którzy niczego nie ukradli, ale dopuœcili siê sabota¿u wobec grupy i nawet uciekli siê do porwania. Zgodzi³em siê obserwowæ i chroniæ tych intelektualistów przed takimi atakami. Na szczêœcie, jeœli ci kopacze przebij¹ siê, mo¿emy znaleŸæ dla siebie coœ unikatowego.~
-~Archeologiczne wykopaliska.
+~Archeologiczne wykopaliska
 
 Spotka³am inspiruj¹cego kopacza imieniem Charleston Nib na zachód od Nashkel. On i jego ekipa odkryli podziemn¹ osadê prymitywnych staro¿ytnch ludzi i s¹ bliscy wejœcia do jednej z wewnêtrznych komnat. Jednak¿e, byli na ³asce bandytów, którzy niczego nie ukradli, ale dopuœcili siê sabota¿u wobec grupy i nawet uciekli siê do porwania. Zgodzi³am siê obserwowæ i chroniæ tych intelektualistów przed takimi atakami. Na szczêœcie, jeœli ci kopacze przebij¹ siê, mo¿emy znaleŸæ dla siebie coœ unikatowego.~
-@310576 = ~Archeologiczne wykopaliska.
+@310576 = ~Archeologiczne wykopaliska
 
 Znalaz³em teren wykopalisk daleko na zachód od Nashkel. Dzia³a tam niejaki Charleston Nib. Nie by³em zainteresowany t¹ nudn¹ histori¹.~
-~Archeologiczne wykopaliska.
+~Archeologiczne wykopaliska
 
 Znalaz³am teren wykopalisk daleko na zachód od Nashkel. Dzia³a tam niejaki Charleston Nib. Nie by³am zainteresowana t¹ nudn¹ histori¹.~
-@310577 = ~Archeologiczne wykopaliska.
+@310577 = ~Archeologiczne wykopaliska
 
 Wygl¹da na to, ¿e sprawa wykopalisk przybra³a postaæ tragiczn¹. Widocznie, przeklêty bo¿yszcze w œrodkowej komnacie spowodowa³ szaleñstwo wœród kopaczy i nie mia³em wyboru ale musia³em siê broniæ. Dni Charlestona zdaj¹ sie byæ policzone w zwi¹zku z zaistnia³¹ sytuacj¹. Grobowiec zostanie zamkniêty i nikt nie bêdzie ponownie przeszkadza³, mam nadziejê.~
-~Archeologiczne wykopaliska.
+~Archeologiczne wykopaliska
 
 Wygl¹da na to, ¿e sprawa wykopalisk przybra³a postaæ tragiczn¹. Widocznie, przeklêty bo¿yszcze w œrodkowej komnacie spowodowa³ szaleñstwo wœród kopaczy i nie mia³am wyboru ale musia³am siê broniæ. Dni Charlestona zdaj¹ sie byæ policzone w zwi¹zku z zaistnia³¹ sytuacj¹. Grobowiec zostanie zamkniêty i nikt nie bêdzie ponownie przeszkadza³, mam nadziejê.~
-@310578 = ~St³umiæ archeologiczne wykopaliska.
+@310578 = ~St³umiæ archeologiczne wykopaliska
 
 Gallor, cz³onek ekipy wykopaliskowej, by³ niezbyt zadowolony z dobroczynnych starañ Charlestona Niba i chcia³ ¿ebym ukrad³ jakiekolwiek magiczne przedmioty na jakie trafiê, gdy wejdê ju¿ z Charlestonem do grobowca, po czym mia³bym zabiæ dowodz¹cego. Nie wezmê udzia³u w tak niewinnym rozlewie krwi.~
-~St³umiæ archeologiczne wykopaliska.
+~St³umiæ archeologiczne wykopaliska
 
 Gallor, cz³onek ekipy wykopaliskowej, by³ niezbyt zadowolony z dobroczynnych starañ Charlestona Niba i chcia³ ¿ebym ukrad³a jakiekolwiek magiczne przedmioty na jakie trafiê, gdy wejdê ju¿ z Charlestonem do grobowca, po czym mia³abym zabiæ dowodz¹cego. Nie wezmê udzia³u w tak niewinnym rozlewie krwi.~
-@310579 = ~St³umiæ archeologiczne wykopaliska.
+@310579 = ~St³umiæ archeologiczne wykopaliska
 
 Obiecano mi bogactwo za pozbycie siê Charlestona Niba i jego ekipy oraz przyniesienie magicznych przedmiotów z terenu wykopalisk, na zachód od Nashkel. Nie jestem sk³onny ich atakowaæ dopóki nie dotr¹ do wnêtrza sanktuarium. Gallor bêdzie czeka³ na zewn¹trz, gdy powrócê.~
-~St³umiæ archeologiczne wykopaliska.
+~St³umiæ archeologiczne wykopaliska
 
 Obiecano mi bogactwo za pozbycie siê Charlestona Niba i jego ekipy oraz przyniesienie magicznych przedmiotów z terenu wykopalisk, na zachód od Nashkel. Nie jestem sk³onna ich atakowaæ dopóki nie dotr¹ do wnêtrza sanktuarium. Gallor bêdzie czeka³ na zewn¹trz, gdy powrócê.~
-@310580 = ~St³umiæ archeologiczne wykopaliska.
+@310580 = ~St³umiæ archeologiczne wykopaliska
 
 Przygody archeologiczne Charlestona Nibsa powinny byæ œpiewane przez ptaki jako opowieœæ o tragedii, gdzie bezwglêdne ataki bandytów doprowadzi³y jego ekipê do œmierci i nie powinny nigdy wiêcej siê powtórzyæ. Bardziej sentymentalny jest dochód, który otrzyma³em za "napisanie" takiej historii.~
-~St³umiæ archeologiczne wykopaliska.
+~St³umiæ archeologiczne wykopaliska
 
 Przygody archeologiczne Charlestona Nibsa powinny byæ œpiewane przez ptaki jako opowieœæ o tragedii, gdzie bezwglêdne ataki bandytów doprowadzi³y jego ekipê do œmierci i nie powinny nigdy wiêcej siê powtórzyæ. Bardziej sentymentalny jest dochód, który otrzyma³am za "napisanie" takiej historii.~
-@310586 = ~Zbadaæ ruiny mostu Firewine.
+@310586 = ~Zbadaæ ruiny mostu Firewine
 
 Nizio³ek z Gullykin imieniem Gandolar spyta³ czy oczyœci³bym ruiny mostu Firewine z koboldów. Powinienem uwa¿aæ, poniewa¿ ró¿ne rodzaje tajemniczych istot mog¹ obudziæ siê ze snu.~
-~Zbadaæ ruiny mostu Firewine.
+~Zbadaæ ruiny mostu Firewine
 
 Nizio³ek z Gullykin imieniem Gandolar spyta³ czy oczyœci³abym ruiny mostu Firewine z koboldów. Powinnam uwa¿aæ, poniewa¿ ró¿ne rodzaje tajemniczych istot mog¹ obudziæ siê ze snu.~
-@310587 = ~Zbadaæ ruiny mostu Firewine.
+@310587 = ~Zbadaæ ruiny mostu Firewine
 
 Wiadomoœci w Gullykin zdaj¹ siê szybciej rozprzestrzeniaæ ni¿ ptak móg³by przelecieæ nad wiosk¹! Moje oczyszczenie obozowiska koboldów w ruinach mostu Firewine przynios³o uœmiechy w wiosce, a mi 250 sztuk z³ota w mojej sakiewce.~
-@310589 = ~Polowanie na wiwerny.
+@310589 = ~Polowanie na wiwerny
 
 Ubi³em wiwernê... Nie, kilka wiwern... w jaskini Kniei Otulisko. Burmistrz Beregostu w œwi¹tyni Lathandera nagrodzi³ mnie przyzwoicie za ten wyczyn.~
-~Polowanie na wiwerny.
+~Polowanie na wiwerny
 
 Ubi³am wiwernê... Nie, kilka wiwern... w jaskini Kniei Otulisko. Burmistrz Beregostu w œwi¹tyni Lathandera nagrodzi³ mnie przyzwoicie za ten wyczyn.~
-@310595 = ~Okup za Skie.
+@310595 = ~Okup za Skie
 
-Pod¹¿aj¹c sukcesywnie wype³niliœmy plan Eldotha, by 'uratowaæ' Skie z posiad³oœci Entara Srebrnej Tarczy. Wraz z Eldothem i Skie mamy spotykaæ siê co dwa dni z cz³owiekiem o imieniu Elkart w gospodzie Ostrza i Gwiazdy, by odbieraæ pieni¹dze za okup. Zdaje siê, ¿e ojciec Skie martwi siê o ni¹, ale widzê szczêœliw¹ parê dziêki wolnoœci Skie, niezale¿nie jak jej rodzina to potêpia. Mimo wszystko, pieni¹dze siê nam przydadz¹.~
-@310596 = ~Okup za Skie.
+Pod¹¿aj¹c sukcesywnie wype³niliœmy plan Eldotha, by "uratowaæ" Skie z posiad³oœci Entara Srebrnej Tarczy. Wraz z Eldothem i Skie mamy spotykaæ siê co dwa dni z cz³owiekiem o imieniu Elkart w gospodzie Ostrza i Gwiazdy, by odbieraæ pieni¹dze za okup. Zdaje siê, ¿e ojciec Skie martwi siê o ni¹, ale widzê szczêœliw¹ parê dziêki wolnoœci Skie, niezale¿nie jak jej rodzina to potêpia. Mimo wszystko, pieni¹dze siê nam przydadz¹.~
+@310596 = ~Okup za Skie
 
 Zdaje siê, ¿e Eldoth kontynuowa³ swoje postanowanie i uparcie odbiera³ pieni¹dze z okupu od konaktu Entara Srebrnej Tarczy, z którego posiad³oœci uciek³a Skie. Byliœmy drêczeni przez P³omienn¹ Piêœæ i nie mogliœmy nic zrobiæ jak walk¹ wyjœæ z tej pu³apki.~
-@310605 = ~Odzyskaæ sztylet Hurgana.
+@310605 = ~Odzyskaæ sztylet Hurgana
 
 By³o zbyt póŸno, by zatrzymaæ kultystów przed przyzwaniem z³ego demona, wiêc nie by³o innego wyjœcia, jak wyci¹æ ich zanim wywarliby spustoszenie w Brodzie Ulgotha i w okolicy. Bitwa by³a ca³kiem trudna, muszê przynaæ... Kiedy myœla³em, ¿e demon jest martwy, zabiera³ dusze swoich wyznawców i wraca³ do ¿ycia dziêki nim.~
-~Odzyskaæ sztylet Hurgana.
+~Odzyskaæ sztylet Hurgana
 
 By³o zbyt póŸno, by zatrzymaæ kultystów przed przyzwaniem z³ego demona, wiêc nie by³o innego wyjœcia, jak wyci¹æ ich zanim wywarliby spustoszenie w Brodzie Ulgotha i w okolicy. Bitwa by³a ca³kiem trudna, muszê przynaæ... Kiedy myœla³am, ¿e demon jest martwy, zabiera³ dusze swoich wyznawców i wraca³ do ¿ycia dziêki nim.~
-@310610 = ~ZnajdŸ syna Therella'i, Daltona, w wie¿y Durlaga.
+@310610 = ~ZnajdŸ syna Therelli, Daltona, w wie¿y Durlaga
 
-Znalaz³em syna Therella'i, ale poniós³ on okropn¹ œmieræ. Nie mog³em ju¿ nic zrobiæ.~
-~ZnajdŸ syna Therella'i, Daltona, w wie¿y Durlaga.
+Znalaz³em syna Therelli, ale poniós³ on okropn¹ œmieræ. Nie mog³em ju¿ nic zrobiæ.~
+~ZnajdŸ syna Therelli, Daltona, w wie¿y Durlaga
 
-Znalaz³am syna Therella'i, ale poniós³ on okropn¹ œmieræ. Nie mog³am ju¿ nic zrobiæ.~
+Znalaz³am syna Therelli, ale poniós³ on okropn¹ œmieræ. Nie mog³am ju¿ nic zrobiæ.~
 @310656 = ~Rozbitkowie!
 
 Burza, która przesz³a, by³a najwiêksz¹ burz¹ jak¹ w ¿yciu widzia³em! Nawet bardziej dziwny jest fakt, ¿e tylko moja dru¿yna przetrwa³a, tak mi siê zdaje. Tu musi dzia³aæ jakaœ magia, jednak nie wiem kto lub co za tym stoi. Jedyn¹ rzecz¹ jak¹ wiem to to, ¿e nie jesteœmy jedynymi ludŸmi na tej tajemniczej wyspie, gdy¿ s¹ tutaj jeszcze mili wieœniacy. Powinienem zapytaæ w okolicy czy ktoœ potrafi zlokalizowaæ wrak statku Baldurana i dziennik Mendasa, bo w³aœnie to mamy znaleŸæ. Po tym wszystkim, s¹dzê, ¿e tylko Bogowie wiedz¹ jak wrócê st¹d do Brody Ulgotha.~
 ~Rozbitkowie!
 
 Burza, która przesz³a, by³a najwiêksz¹ burz¹ jak¹ w ¿yciu widzia³am! Nawet bardziej dziwny jest fakt, ¿e tylko moja dru¿yna przetrwa³a, tak mi siê zdaje. Tu musi dzia³aæ jakaœ magia, jednak nie wiem kto lub co za tym stoi. Jedyn¹ rzecz¹ jak¹ wiem to to, ¿e nie jesteœmy jedynymi ludŸmi na tej tajemniczej wyspie, gdy¿ s¹ tutaj jeszcze mili wieœniacy. Powinnam zapytaæ w okolicy czy ktoœ potrafi zlokalizowaæ wrak statku Baldurana i dziennik Mendasa, bo w³aœnie to mamy znaleŸæ. Po tym wszystkim, s¹dzê, ¿e tylko Bogowie wiedz¹ jak wrócê st¹d do Brody Ulgotha.~
-@310793 = ~Zdob¹dŸ p³aszcz Shandalara.
+@310793 = ~Zdob¹dŸ p³aszcz Shandalara
 
 Zdaje siê, ¿e moje sprawy z Gildi¹ Z³odziei nie posz³y w zapomnienie. Shandalar, który mia³ trzy córki chroni¹ce komponenty statku powietrznego, zwabi³ mnie do kary za œmieræ jego córek. Teleportowa³ mnie na tajemnicz¹, lodowat¹ wyspê, na œrodku oceanu! Wspomnia³, ¿e mam znaleŸæ jego p³aszcz. Po jego znalezieniu, powinien pozwoliæ mi wydostaæ siê z tej wyspy. Muszê mieæ szeroko otwarte oczy.~
-@310809 = ~Zdob¹dŸ p³aszcz Shandalara.
+@310809 = ~Zdob¹dŸ p³aszcz Shandalara
 
 Wbrew mojej woli zosta³em zmuszony, by podj¹æ siê zadania nieuprzejmego maga w centrum Brody Ulgotha. Wys³a³ mnie na wyja³owion¹, lodow¹ wyspê, bym znalaz³ jego p³aszcz. To bêdzie prawdopodobnie jego b³¹d, ¿e umo¿liwi³ mi powrót dziêki kamieniowi stra¿niczemu, który mi da³, bo policzê siê z nim po moim powrocie.~
-~Zdob¹dŸ p³aszcz Shandalara.
+~Zdob¹dŸ p³aszcz Shandalara
 
 Wbrew mojej woli zosta³am zmuszona, by podj¹æ siê zadania nieuprzejmego maga w centrum Brody Ulgotha. Wys³a³ mnie na wyja³owion¹, lodow¹ wyspê, bym znalaz³a jego p³aszcz. To bêdzie prawdopodobnie jego b³¹d, ¿e umo¿liwi³ mi powrót dziêki kamieniowi stra¿niczemu, który mi da³, bo policzê siê z nim po moim powrocie.~
-@310810 = ~Zdob¹dŸ p³aszcz Shandalara.
+@310810 = ~Zdob¹dŸ p³aszcz Shandalara
 
 Zaakceptowa³em jak widaæ proste zadanie odzyskania p³aszcza maga, Shandalara, którego spotka³em w Brodzie Ulgotha. Widocznie proste, ale szokuj¹ce by³o, moje przeniesienie na opuszczon¹ wysepkê wœród lodowatego oceanu! Ten oszust uwiêzi³ mnie, aczkolwiek wspomnia³ coœ o uwolnieniu, co ma zapewniæ mi kamieñ, który otrzyma³em. Powinienem szybko znaleŸæ jego p³aszcz... bo zimno tu.~
-~Zdob¹dŸ p³aszcz Shandalara.
+~Zdob¹dŸ p³aszcz Shandalara
 
 Zaakceptowa³am jak widaæ proste zadanie odzyskania p³aszcza maga, Shandalara, którego spotka³am w Brodzie Ulgotha. Widocznie proste, ale szokuj¹ce by³o, moje przeniesienie na opuszczon¹ wysepkê wœród lodowatego oceanu! Ten oszust uwiêzi³ mnie, aczkolwiek wspomnia³ coœ o uwolnieniu, co ma zapewniæ mi kamieñ, który otrzyma³am. Powinnam szybko znaleŸæ jego p³aszcz... bo zimno tu.~
-@310811 = ~Zdob¹dŸ p³aszcz Shandalara.
+@310811 = ~Zdob¹dŸ p³aszcz Shandalara
 
 Cieszê siê widz¹c ponownie zaklêcia Shandalara jak i jego p³aszcz. Lodowe wiêzienie, do którego zosta³em przeniesiony, nie by³o zbyt przytulnym miejscem. Widocznie powinienem teraz bardziej uwa¿aæ na rozdra¿nionych magów.~
-~Zdob¹dŸ p³aszcz Shandalara.
+~Zdob¹dŸ p³aszcz Shandalara
 
 Cieszê siê widz¹c ponownie zaklêcia Shandalara jak i jego p³aszcz. Lodowe wiêzienie, do którego zosta³am przeniesiona, nie by³o zbyt przytulnym miejscem. Widocznie powinnam teraz bardziej uwa¿aæ na rozdra¿nionych magów.~
-@310812 = ~Zdob¹dŸ p³aszcz Shandalara.
+@310812 = ~Zdob¹dŸ p³aszcz Shandalara
 
 Ten nikczemny mag uciek³ mi zanim zd¹¿y³em odebraæ nagrodê za tê niepotrzebn¹ przygodê! Ostatni¹ rzecz¹ jak¹ powinienem zrobiæ to uwa¿aæ na krytycznoœæ mojej postawy. Bez wzglêdu na to, cieszê siê, ¿e spotka³em go, jego p³aszcz i to lodowe wiêzienie.~
-~Zdob¹dŸ p³aszcz Shandalara.
+~Zdob¹dŸ p³aszcz Shandalara
 
 Ten nikczemny mag uciek³ mi zanim zd¹¿y³am odebraæ nagrodê za tê niepotrzebn¹ przygodê! Ostatni¹ rzecz¹ jak¹ powinnam zrobiæ to uwa¿aæ na krytycznoœæ mojej postawy. Bez wzglêdu na to, cieszê siê, ¿e spotka³am go, jego p³aszcz i to lodowe wiêzienie.~
-@310813 = ~Zdob¹dŸ p³aszcz Shandalara.
+@310813 = ~Zdob¹dŸ p³aszcz Shandalara
 
 Zdoby³em p³aszcz Shandalara. Z pewnoœci¹ nie chcia³bym tam wróciæ ponownie. Na myœl tego miejsca przechodz¹ mi ciarki. Powinienem siê cieszyæ, ¿e mia³em kamieñ stra¿niczy i znalaz³em sposób na powrót do Brody Ulgotha. Chyba nie spotkam ju¿ wiêcej tego maga, a ukara³em go ju¿ chyba wczeœniej - œmierci¹ jego córek. Bez wzglêdu na to, cieszê siê, ¿e spotka³em go, jego p³aszcz i to lodowe wiêzienie.~
-~Zdob¹dŸ p³aszcz Shandalara.
+~Zdob¹dŸ p³aszcz Shandalara
 
 Zdoby³am p³aszcz Shandalara. Z pewnoœci¹ nie chcia³abym tam wróciæ ponownie. Na myœl tego miejsca przechodz¹ mi ciarki. Powinnam siê cieszyæ, ¿e mia³am kamieñ stra¿niczy i znalaz³am sposób na powrót do Brody Ulgotha. Chyba nie spotkam ju¿ wiêcej tego maga, a ukara³am go ju¿ chyba wczeœniej - œmierci¹ jego córek. Bez wzglêdu na to, cieszê siê, ¿e spotka³am go, jego p³aszcz i to lodowe wiêzienie.~
 
@@ -1189,21 +1186,21 @@ Twoja wêdrówka zatoczy³a pe³en kr¹g. Ksi¹¿ê Eltan poprosi³ ciê o powrót do Candl
 //////////////////
 //VOLO.DLG
 /*JOURNAL - @8534*/
-@310444 = ~Wieœæ od Volo.
+@310444 = ~Wieœæ od Volo
 
 Wiele zebra³em historii dotycz¹cych tego œwiata, chocia¿ czasem sam nie wiedzia³em, czy wierzyæ w nie, czy nie, tak bardzo by³y niezwyk³e. Takie jak owa opowieœæ o grupie dzielnych poszukiwaczy przygód, którzy podró¿owali przez œwiat docieraj¹c wszêdzie tam, gdzie potrzebna by³a ich pomoc. Bawi³em w³aœnie na skromnych uroczystoœciach w Nashkel, kiedy miasto obieg³a zdumiewaj¹ca wieœæ. Otó¿ kopalnie, w których wydarzy³o siê wiele niewyjaœnionych œmiertelnych wypadków, zosta³y nawiedzone przez plagê koboldów pod dowództwem podejrzanego i pozbawionego skrupu³ów kap³ana Cyrika. Mieszkañcy pos³ali grupê œmia³ków, którzy uwolnili podziemne szyby od wrogów i w³aœnie dlatego do Wrót Baldura znów docieraj¹ dostawy ¿elaza. Nikt nie pamiêta imion tych œmia³ków, ale wszyscy zgadzaj¹ siê, ¿e byli oni podobni olbrzymom i niezrównani w walce.~
 
 /*JOURNAL - @8535*/
-@310445 = ~Wieœæ od Volo.
+@310445 = ~Wieœæ od Volo
 
 Opowiada³em ju¿ dziwniejsze historie, ale tê pamiêtam nad wyraz dobrze, zw³aszcza ¿e wydarzy³a siê niedawno. Zdarzy³o siê tak, ¿e zarz¹dcy wci¹¿ niewystarczaj¹cych zapasów ¿elaza zaczêli zasilaæ siebie i swoich przyjació³ z³o¿ami pochodz¹cymi z tajnej kopalni, a kiedy wybrze¿e ogarn¹³ chaos, zbudowali potê¿n¹ bazê we wspomnianej kopalni. Grupa bohaterów, bo tylko tak mo¿na ich nazwaæ, otoczy³a wrogi obóz i ostatecznie zatopi³a konspiratorów i sprawiedliwoœci sta³o siê zadoœæ. Niestety, bohaterowie nie zdo³ali ocaliæ ¿ycia kilku tuzinów niewolników zmuszonych do pracy w kopalni. Jestem pewien, ¿e to by³ powa¿ny cios dla tych, którzy próbowali knuæ z³owrogie intrygi.~
 
 /*JOURNAL - @8536*/
-@310446 = ~Wieœæ od Volo.
+@310446 = ~Wieœæ od Volo
 
 Opowiada³em ju¿ dziwniejsze historie, ale tê pamiêtam nad wyraz dobrze, zw³aszcza ¿e wydarzy³a siê niedawno. Zdarzy³o siê tak, ¿e zarz¹dcy wci¹¿ niewystarczaj¹cych zapasów ¿elaza zaczêli zasilaæ siebie i swoich przyjació³ z³o¿ami pochodz¹cymi z tajnej kopalni, a kiedy wybrze¿e ogarn¹³ chaos, zbudowali potê¿n¹ bazê we wspomnianej kopalni. Grupa bohaterów, bo tylko tak mo¿na ich nazwaæ, otoczy³a wrogi obóz i ostatecznie zatopi³a konspiratorów i sprawiedliwoœci sta³o siê zadoœæ. Niestety, bohaterowie nie zdo³ali ocaliæ ¿ycia kilku tuzinów niewolników zmuszonych do pracy w kopalni. Jestem pewien, ¿e to by³ powa¿ny cios dla tych, którzy próbowali knuæ z³owrogie intrygi. Pytanie brzmi: czy znany diabe³ jest lepszy od nieznanego... Poczekamy, zobaczymy...~
 
 /*JOURNAL - @8537*/
-@310447 = ~Wieœæ od Volo.
+@310447 = ~Wieœæ od Volo
 
 Niektóre opowieœci wymykaj¹ siê logicznym wyt³umaczeniom, i taka te¿ jest historia, któr¹ ci teraz opowiem. By³o o niej g³oœno, bowiem jej bohaterami sta³y siê znane osobistoœci. Wielu wci¹¿ uwa¿a za niezwykle szokuj¹ce, jak g³êboko zasiane zosta³y ziarna zniszczenia. Ukochany Sarevok, najlepszy z najlepszych, by³ tak naprawdê g³ównym sprawc¹ braku dostaw ¿elaza, co zachwia³o ekonomi¹ krainy. Ponadto macza³ on palce w otruciu ksiêcia Eltana, co bezpoœrednio pomog³o mu w rozszerzeniu swej w³adzy. Byliœmy o krok od upadku, gdy z cieni wy³oni³a siê grupa nieznanych bohaterów moich poprzednich opowieœci. Nikt nie jest pewien, co tak naprawdê siê sta³o, wiadomo jednak, ¿e Sarevok zosta³ wypêdzony do najni¿szego poziomu Podziemnego Miasta, z którego to miejsca ju¿ nie powróci³. Niektórzy wierz¹, ¿e za wszystkie krzywdy, które wyrz¹dzi³, zosta³ zes³any do najgorszego zak¹tka otch³ani.~

--- a/bgt/language/polish/journal.tra
+++ b/bgt/language/polish/journal.tra
@@ -496,7 +496,7 @@
 @800165 = ~Wygl¹daj¹cy na starego mag œledzi mnie dooko³a.
 
 ~
-@800166 = ~ZnajdŸ Jaheirê i Khalid jeœli czujesz potrzebê.
+@800166 = ~ZnajdŸ Jaheirê i Khalida jeœli czujesz potrzebê.
 
 ~
 @800167 = ~Stara dobra Imoen!


### PR DESCRIPTION
Based on Polish BG2 GTU prework and EE convention, I prepared a cleanup for BG1 Polish journal entries. 
This PR includes: 
- Fixed typo in Khalid name,
- Added missing tripledots in one of the sentense.
- Removed dots at the end of journal title (the same way as EE did)
- Fixed some incorectly used apostrophies in NPC names (example: Therella'i vs Therelli)
- Changed some ' ' into " "