### PR TITLE
Fix gap hours in random encounters

### DIFF
--- a/bgt/base/baf/ar4901.baf
+++ b/bgt/base/baf/ar4901.baf
@@ -14,7 +14,7 @@ END
 IF
 	Global("A6WaylaidSpawn","AR4901",0)
 	TimeGT(2)
-	TimeLT(4)
+	TimeLT(5)
 THEN
 	RESPONSE #100
 		CreateCreature("JELLMU",[851.122],0)  // Mustard Jelly

--- a/bgt/base/baf/ar5100.baf
+++ b/bgt/base/baf/ar5100.baf
@@ -29,7 +29,7 @@ END
 IF
 	Global("A6WaylaidSpawn","AR5100",0)
 	TimeGT(4)
-	TimeLT(DAWN_START)
+	TimeLT(DAWN_END)
 THEN
 	RESPONSE #100
 		CreateCreature("BGWOLF",[628.346],0)  // Wolf


### PR DESCRIPTION
Reported by Azdul on [SHS Forums](http://www.shsforums.net/topic/61906-random-encounter-with-nothing/)
Investigated and [fixed](http://www.shsforums.net/topic/61906-random-encounter-with-nothing/#entry616151) by Salk

Random encounter scripts AR4901 and AR5100 had gap hours in creature spawns based on the time of day.